### PR TITLE
Restructure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN git clone https://github.com/SpikeInterface/spikeinterface.git && \
 # Install spikeinterface-gui from source
 RUN git clone https://github.com/alejoe91/spikeinterface-gui.git && \
     cd spikeinterface-gui && \
-    git checkout 3af19c6ac4187354cbd4066fec492afd98a69cc5 && \
+    git checkout 6fc4577c71594a6d3a32b8c423bd09d18e0950dd && \
     pip install . && cd ..
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,9 @@ RUN git clone https://github.com/SpikeInterface/spikeinterface.git && \
 # Install spikeinterface-gui from source
 RUN git clone https://github.com/alejoe91/spikeinterface-gui.git && \
     cd spikeinterface-gui && \
-    git checkout 6fc4577c71594a6d3a32b8c423bd09d18e0950dd && \
+    git checkout c165cfe91ea8dcfdc69836184db9827304d357f9 && \
     pip install . && cd ..
 
 
 EXPOSE 8000
-ENTRYPOINT ["sh", "-c", "panel serve src/aind_ephys_portal/ephys_gui_app.py src/aind_ephys_portal/ephys_launcher_app.py src/aind_ephys_portal/ephys_monitor_app.py src/aind_ephys_portal/ephys_log_app.py --setup src/aind_ephys_portal/setup.py --static-dirs images=src/aind_ephys_portal/images --address 0.0.0.0 --port 8000 --allow-websocket-origin ${ALLOW_WEBSOCKET_ORIGIN} --keep-alive 180 --index ephys_portal_app.py --num-procs 1 --num-threads 8"]
+ENTRYPOINT ["sh", "-c", "panel serve src/aind_ephys_portal/ephys_gui_app.py src/aind_ephys_portal/ephys_portal_app.py src/aind_ephys_portal/ephys_launcher_app.py src/aind_ephys_portal/ephys_monitor_app.py --setup src/aind_ephys_portal/setup.py --static-dirs images=src/aind_ephys_portal/images --address 0.0.0.0 --port 8000 --allow-websocket-origin ${ALLOW_WEBSOCKET_ORIGIN} --index ephys_portal_app.py --check-unused-sessions 2000 --unused-session-lifetime 5000 --num-procs 4"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ RUN git clone https://github.com/alejoe91/spikeinterface-gui.git && \
 
 
 EXPOSE 8000
-ENTRYPOINT ["sh", "-c", "panel serve src/aind_ephys_portal/ephys_portal_app.py src/aind_ephys_portal/ephys_gui_app.py --setup src/aind_ephys_portal/setup.py --static-dirs images=src/aind_ephys_portal/images --address 0.0.0.0 --port 8000 --allow-websocket-origin ${ALLOW_WEBSOCKET_ORIGIN} --keep-alive 10000 --index ephys_portal_app.py --num-procs 4 --warm"]
+ENTRYPOINT ["sh", "-c", "panel serve src/aind_ephys_portal/ephys_gui_app.py src/aind_ephys_portal/ephys_launcher_app.py src/aind_ephys_portal/ephys_monitor_app.py src/aind_ephys_portal/ephys_log_app.py --setup src/aind_ephys_portal/setup.py --static-dirs images=src/aind_ephys_portal/images --address 0.0.0.0 --port 8000 --allow-websocket-origin ${ALLOW_WEBSOCKET_ORIGIN} --keep-alive 180 --index ephys_portal_app.py --num-procs 1 --num-threads 8"]

--- a/README.md
+++ b/README.md
@@ -24,10 +24,24 @@ pip install -e .
 
 ## Usage
 
-To run the Ephys Portal:
+To run the Ephys Portal you can either use tha `launch.sh` script:
 
 ```bash
-panel serve src/aind_ephys_portal/ephys_gui_app.py src/aind_ephys_portal/ephys_launcher_app.py src/aind_ephys_portal/ephys_monitor_app.py src/aind_ephys_portal/ephys_log_app.py --setup src/aind_ephys_portal/setup.py --static-dirs images=src/aind_ephys_portal/images --keep-alive 10000 --index ephys_portal_app.py --num-procs 4 --warm
+bash launch.sh
+```
+
+or serve panel apps directly:
+
+```bash
+panel serve \
+    src/aind_ephys_portal/ephys_gui_app.py \
+    src/aind_ephys_portal/ephys_launcher_app.py \
+    src/aind_ephys_portal/ephys_monitor_app.py \
+    src/aind_ephys_portal/ephys_log_app.py \
+    --setup src/aind_ephys_portal/setup.py \
+    --static-dirs images=src/aind_ephys_portal/images \
+    --index ephys_portal_app.py \
+    --num-procs 4
 ```
 
 This will start a Panel server and make the application available in your web browser.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ pip install -e .
 To run the Ephys Portal:
 
 ```bash
-# Run using Panel CLI (recommended for server deployment)
-panel serve src/aind_ephys_portal/ephys_portal_app.py src/aind_ephys_portal/ephys_gui_app.py  --setup src/aind_ephys_portal/setup.py --static-dirs images=src/aind_ephys_portal/images --num-procs 8
+panel serve src/aind_ephys_portal/ephys_gui_app.py src/aind_ephys_portal/ephys_launcher_app.py src/aind_ephys_portal/ephys_monitor_app.py src/aind_ephys_portal/ephys_log_app.py --setup src/aind_ephys_portal/setup.py --static-dirs images=src/aind_ephys_portal/images --keep-alive 10000 --index ephys_portal_app.py --num-procs 4 --warm
 ```
 
 This will start a Panel server and make the application available in your web browser.

--- a/launch.sh
+++ b/launch.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Clean up old logs
+rm -rf /tmp/aind_ephys_logs
+
 panel serve \
     src/aind_ephys_portal/ephys_gui_app.py \
     src/aind_ephys_portal/ephys_portal_app.py \

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+panel serve \
+    src/aind_ephys_portal/ephys_gui_app.py \
+    src/aind_ephys_portal/ephys_portal_app.py \
+    src/aind_ephys_portal/ephys_launcher_app.py \
+    src/aind_ephys_portal/ephys_monitor_app.py \
+    --setup src/aind_ephys_portal/setup.py \
+    --static-dirs images=src/aind_ephys_portal/images \
+    --check-unused-sessions 2000 \
+    --unused-session-lifetime 5000 \
+    --num-procs 4

--- a/src/aind_ephys_portal/docdb/database.py
+++ b/src/aind_ephys_portal/docdb/database.py
@@ -102,7 +102,7 @@ def get_raw_asset_by_name(asset_name: str):
 
 
 @pn.cache(ttl=TIMEOUT_1H)
-def get_all_ecephys_derived(additional_includes_in_name : str | None =None) -> List[Dict[str, Any]]:
+def get_all_ecephys_derived(additional_includes_in_name: str | None = None) -> List[Dict[str, Any]]:
     """Get a limited set of all records from the database.
 
     Returns

--- a/src/aind_ephys_portal/docdb/database.py
+++ b/src/aind_ephys_portal/docdb/database.py
@@ -102,16 +102,27 @@ def get_raw_asset_by_name(asset_name: str):
 
 
 @pn.cache(ttl=TIMEOUT_1H)
-def get_all_ecephys_derived() -> List[Dict[str, Any]]:
+def get_all_ecephys_derived(additional_includes_in_name : str | None =None) -> List[Dict[str, Any]]:
     """Get a limited set of all records from the database.
 
     Returns
     -------
     list[dict]
         List of records, limited to 50 entries.
+    additional_includes_in_name : str, optional
+        Comma-separated list of additional fields to include in the results, by default None
     """
     filter_query = {"data_description.modality.abbreviation": "ecephys", "data_description.data_level": "derived"}
-    response = client.retrieve_docdb_records(
+    responses = client.retrieve_docdb_records(
         filter_query=filter_query,
     )
-    return response
+    responses_filt = []
+    if additional_includes_in_name:
+        additional_fields = [field.strip() for field in additional_includes_in_name.split(",")]
+        for record in responses:
+            for field in additional_fields:
+                if field in record["name"]:
+                    responses_filt.append(record)
+    else:
+        responses_filt = responses
+    return responses_filt

--- a/src/aind_ephys_portal/ephys_gui_app.py
+++ b/src/aind_ephys_portal/ephys_gui_app.py
@@ -19,15 +19,19 @@ class Settings(param.Parameterized):
 
     analyzer_path = param.String(default="")
     recording_path = param.String(default="")
+    fast_mode = param.Boolean(
+        default=False,
+        doc="Whether to enable fast mode (skips waveforms and principal components)"
+    )
 
 
 settings = Settings()
-pn.state.location.sync(settings, {"analyzer_path": "analyzer_path", "recording_path": "recording_path"})
+pn.state.location.sync(settings, {"analyzer_path": "analyzer_path", "recording_path": "recording_path", "fast_mode": "fast_mode"})
 
 # Manually decode stream_name after syncing
 settings.analyzer_path = urllib.parse.unquote(settings.analyzer_path)
 settings.recording_path = urllib.parse.unquote(settings.recording_path)
 
-ephys_gui = EphysGuiView(analyzer_path=settings.analyzer_path, recording_path=settings.recording_path)
+ephys_gui = EphysGuiView(analyzer_path=settings.analyzer_path, recording_path=settings.recording_path, fast_mode=settings.fast_mode)
 
 ephys_gui.panel().servable(title="AIND Ephys GUI")

--- a/src/aind_ephys_portal/ephys_gui_app.py
+++ b/src/aind_ephys_portal/ephys_gui_app.py
@@ -4,6 +4,7 @@ import urllib
 import param
 
 import panel as pn
+
 pn.extension("tabulator", "gridstack")
 
 # Import for side effects: registers SpikeInterface GUI custom Panel/Bokeh models/resources
@@ -15,6 +16,7 @@ from aind_ephys_portal.panel.ephys_gui import EphysGuiView
 # State sync
 class Settings(param.Parameterized):
     """Top-level settings for QC app"""
+
     analyzer_path = param.String(default="")
     recording_path = param.String(default="")
 

--- a/src/aind_ephys_portal/ephys_gui_app.py
+++ b/src/aind_ephys_portal/ephys_gui_app.py
@@ -3,7 +3,6 @@
 import urllib
 import param
 
-
 import panel as pn
 pn.extension("tabulator", "gridstack")
 
@@ -16,7 +15,6 @@ from aind_ephys_portal.panel.ephys_gui import EphysGuiView
 # State sync
 class Settings(param.Parameterized):
     """Top-level settings for QC app"""
-
     analyzer_path = param.String(default="")
     recording_path = param.String(default="")
 
@@ -29,6 +27,5 @@ settings.analyzer_path = urllib.parse.unquote(settings.analyzer_path)
 settings.recording_path = urllib.parse.unquote(settings.recording_path)
 
 ephys_gui = EphysGuiView(analyzer_path=settings.analyzer_path, recording_path=settings.recording_path)
-app_layout = pn.Column(ephys_gui.layout, sizing_mode="stretch_both", min_height=600)
 
-app_layout.servable(title="AIND Ephys GUI")
+ephys_gui.panel().servable(title="AIND Ephys GUI")

--- a/src/aind_ephys_portal/ephys_launcher_app.py
+++ b/src/aind_ephys_portal/ephys_launcher_app.py
@@ -1,0 +1,99 @@
+"""Standalone launcher page to generate GUI links."""
+
+import urllib.parse
+
+import panel as pn
+
+from aind_ephys_portal.panel.utils import EPHYSGUI_LINK_PREFIX
+
+pn.extension()
+
+
+analyzer_input = pn.widgets.TextInput(
+    name="Analyzer path",
+    value="",
+    height=50,
+    sizing_mode="stretch_width",
+)
+recording_input = pn.widgets.TextInput(
+    name="Recording path (optional)",
+    value="",
+    height=50,
+    sizing_mode="stretch_width",
+)
+
+generate_button = pn.widgets.Button(
+    name="Generate Link",
+    button_type="primary",
+    height=45,
+    sizing_mode="stretch_width",
+)
+
+status = pn.pane.Markdown("", sizing_mode="stretch_width")
+link_pane = pn.pane.HTML("", sizing_mode="stretch_width")
+url_output = pn.widgets.TextInput(
+    name="GUI URL",
+    value="",
+    disabled=True,
+    sizing_mode="stretch_width",
+)
+
+
+def _build_gui_url():
+    analyzer_path = analyzer_input.value.strip()
+    recording_path = recording_input.value.strip()
+    if not analyzer_path:
+        return None
+
+    analyzer_path_q = urllib.parse.quote(analyzer_path, safe="")
+    recording_path_q = urllib.parse.quote(recording_path, safe="") if recording_path else ""
+    path = EPHYSGUI_LINK_PREFIX.format(analyzer_path_q, recording_path_q)
+
+    location = pn.state.location
+    if location is not None:
+        href = getattr(location, "href", None)
+        if href:
+            parsed = urllib.parse.urlparse(href)
+            if parsed.scheme and parsed.netloc:
+                return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+        protocol = getattr(location, "protocol", "")
+        hostname = getattr(location, "hostname", "")
+        port = getattr(location, "port", "")
+        if protocol and hostname:
+            netloc = f"{hostname}:{port}" if port else hostname
+            return f"{protocol}//{netloc}{path}"
+
+    return path
+
+
+def _update_link(event=None):
+    url = _build_gui_url()
+    if not url:
+        status.object = "⚠️ Analyzer path is required."
+        link_pane.object = ""
+        url_output.value = ""
+        return
+
+    status.object = ""
+    link_pane.object = f"<a href=\"{url}\" target=\"_blank\">Open Ephys GUI</a>"
+    url_output.value = url
+
+
+generate_button.on_click(_update_link)
+# analyzer_input.param.watch(_update_link, "value")
+# recording_input.param.watch(_update_link, "value")
+
+
+app_layout = pn.Column(
+    pn.pane.Markdown("## AIND Ephys Launcher"),
+    analyzer_input,
+    recording_input,
+    generate_button,
+    status,
+    link_pane,
+    url_output,
+    sizing_mode="stretch_width",
+)
+
+app_layout.servable(title="AIND Ephys Launcher")

--- a/src/aind_ephys_portal/ephys_launcher_app.py
+++ b/src/aind_ephys_portal/ephys_launcher_app.py
@@ -54,7 +54,6 @@ class EphysLauncher:
             sizing_mode="stretch_width",
         )
 
-    
     def _build_gui_url(self):
         analyzer_path = self.analyzer_input.value.strip()
         recording_path = self.recording_input.value.strip()
@@ -82,7 +81,6 @@ class EphysLauncher:
 
         return path
 
-
     def _update_link(self, event=None):
         url = self._build_gui_url()
         if not url:
@@ -91,7 +89,7 @@ class EphysLauncher:
             return
         print(f"Generated URL: {url}")
 
-        self.link_pane.object = f"<a href=\"{url}\" target=\"_blank\">Ephys Curation GUI</a>"
+        self.link_pane.object = f'<a href="{url}" target="_blank">Ephys Curation GUI</a>'
         self.url_output.value = url
 
 

--- a/src/aind_ephys_portal/ephys_launcher_app.py
+++ b/src/aind_ephys_portal/ephys_launcher_app.py
@@ -4,96 +4,96 @@ import urllib.parse
 
 import panel as pn
 
+from aind_ephys_portal.panel.logging import setup_logging
 from aind_ephys_portal.panel.utils import EPHYSGUI_LINK_PREFIX
 
 pn.extension()
 
 
-analyzer_input = pn.widgets.TextInput(
-    name="Analyzer path",
-    value="",
-    height=50,
-    sizing_mode="stretch_width",
-)
-recording_input = pn.widgets.TextInput(
-    name="Recording path (optional)",
-    value="",
-    height=50,
-    sizing_mode="stretch_width",
-)
+class EphysLauncher:
+    def __init__(self):
+        setup_logging()
 
-generate_button = pn.widgets.Button(
-    name="Generate Link",
-    button_type="primary",
-    height=45,
-    sizing_mode="stretch_width",
-)
+        self.analyzer_input = pn.widgets.TextInput(
+            name="Analyzer path",
+            value="",
+            height=50,
+            sizing_mode="stretch_width",
+        )
+        self.recording_input = pn.widgets.TextInput(
+            name="Recording path (optional)",
+            value="",
+            height=50,
+            sizing_mode="stretch_width",
+        )
 
-status = pn.pane.Markdown("", sizing_mode="stretch_width")
-link_pane = pn.pane.HTML("", sizing_mode="stretch_width")
-url_output = pn.widgets.TextInput(
-    name="GUI URL",
-    value="",
-    disabled=True,
-    sizing_mode="stretch_width",
-)
+        self.generate_button = pn.widgets.Button(
+            name="Generate Link",
+            button_type="primary",
+            height=45,
+            sizing_mode="stretch_width",
+        )
 
+        self.link_pane = pn.pane.HTML("No link generated yet.", sizing_mode="stretch_width")
+        self.url_output = pn.widgets.TextInput(
+            name="GUI URL",
+            value="",
+            disabled=True,
+            sizing_mode="stretch_width",
+        )
 
-def _build_gui_url():
-    analyzer_path = analyzer_input.value.strip()
-    recording_path = recording_input.value.strip()
-    if not analyzer_path:
-        return None
+        self.generate_button.on_click(self._update_link)
 
-    analyzer_path_q = urllib.parse.quote(analyzer_path, safe="")
-    recording_path_q = urllib.parse.quote(recording_path, safe="") if recording_path else ""
-    path = EPHYSGUI_LINK_PREFIX.format(analyzer_path_q, recording_path_q)
+        self.layout = pn.Column(
+            pn.pane.Markdown("## AIND Ephys Launcher"),
+            self.analyzer_input,
+            self.recording_input,
+            self.generate_button,
+            self.link_pane,
+            self.url_output,
+            sizing_mode="stretch_width",
+        )
 
-    location = pn.state.location
-    if location is not None:
-        href = getattr(location, "href", None)
-        if href:
-            parsed = urllib.parse.urlparse(href)
-            if parsed.scheme and parsed.netloc:
-                return f"{parsed.scheme}://{parsed.netloc}{path}"
+    
+    def _build_gui_url(self):
+        analyzer_path = self.analyzer_input.value.strip()
+        recording_path = self.recording_input.value.strip()
+        if not analyzer_path:
+            return None
 
-        protocol = getattr(location, "protocol", "")
-        hostname = getattr(location, "hostname", "")
-        port = getattr(location, "port", "")
-        if protocol and hostname:
-            netloc = f"{hostname}:{port}" if port else hostname
-            return f"{protocol}//{netloc}{path}"
+        analyzer_path_q = urllib.parse.quote(analyzer_path, safe="")
+        recording_path_q = urllib.parse.quote(recording_path, safe="") if recording_path else ""
+        path = EPHYSGUI_LINK_PREFIX.format(analyzer_path_q, recording_path_q)
 
-    return path
+        location = pn.state.location
+        if location is not None:
+            href = getattr(location, "href", None)
+            if href:
+                parsed = urllib.parse.urlparse(href)
+                if parsed.scheme and parsed.netloc:
+                    return f"{parsed.scheme}://{parsed.netloc}{path}"
 
+            protocol = getattr(location, "protocol", "")
+            hostname = getattr(location, "hostname", "")
+            port = getattr(location, "port", "")
+            if protocol and hostname:
+                netloc = f"{hostname}:{port}" if port else hostname
+                return f"{protocol}//{netloc}{path}"
 
-def _update_link(event=None):
-    url = _build_gui_url()
-    if not url:
-        status.object = "⚠️ Analyzer path is required."
-        link_pane.object = ""
-        url_output.value = ""
-        return
-
-    status.object = ""
-    link_pane.object = f"<a href=\"{url}\" target=\"_blank\">Open Ephys GUI</a>"
-    url_output.value = url
-
-
-generate_button.on_click(_update_link)
-# analyzer_input.param.watch(_update_link, "value")
-# recording_input.param.watch(_update_link, "value")
+        return path
 
 
-app_layout = pn.Column(
-    pn.pane.Markdown("## AIND Ephys Launcher"),
-    analyzer_input,
-    recording_input,
-    generate_button,
-    status,
-    link_pane,
-    url_output,
-    sizing_mode="stretch_width",
-)
+    def _update_link(self, event=None):
+        url = self._build_gui_url()
+        if not url:
+            self.link_pane.object = "<span style='color: orange;'>⚠️ Analyzer path is required.</span>"
+            self.url_output.value = ""
+            return
+        print(f"Generated URL: {url}")
 
-app_layout.servable(title="AIND Ephys Launcher")
+        self.link_pane.object = f"<a href=\"{url}\" target=\"_blank\">Ephys Curation GUI</a>"
+        self.url_output.value = url
+
+
+app = EphysLauncher()
+app.layout.servable(title="AIND Ephys Launcher")

--- a/src/aind_ephys_portal/ephys_launcher_app.py
+++ b/src/aind_ephys_portal/ephys_launcher_app.py
@@ -34,6 +34,13 @@ class EphysLauncher:
             sizing_mode="stretch_width",
         )
 
+        self.fast_mode_checkbox = pn.widgets.Checkbox(
+            name="Enable Fast Mode (skip waveforms and PCs)",
+            value=False,
+            height=30,
+            sizing_mode="stretch_width",
+        )
+
         self.link_pane = pn.pane.HTML("No link generated yet.", sizing_mode="stretch_width")
         self.url_output = pn.widgets.TextInput(
             name="GUI URL",
@@ -48,7 +55,7 @@ class EphysLauncher:
             pn.pane.Markdown("## AIND Ephys Launcher"),
             self.analyzer_input,
             self.recording_input,
-            self.generate_button,
+            pn.Row(self.generate_button, self.fast_mode_checkbox, sizing_mode="stretch_width"),
             self.link_pane,
             self.url_output,
             sizing_mode="stretch_width",
@@ -63,6 +70,8 @@ class EphysLauncher:
         analyzer_path_q = urllib.parse.quote(analyzer_path, safe="")
         recording_path_q = urllib.parse.quote(recording_path, safe="") if recording_path else ""
         path = EPHYSGUI_LINK_PREFIX.format(analyzer_path_q, recording_path_q)
+        if self.fast_mode_checkbox.value:
+            path += "&fast_mode=true"
 
         location = pn.state.location
         if location is not None:

--- a/src/aind_ephys_portal/ephys_monitor_app.py
+++ b/src/aind_ephys_portal/ephys_monitor_app.py
@@ -1,6 +1,8 @@
 import panel as pn
 import psutil
 
+from aind_ephys_portal.panel.logging import list_buffers, remove_buffer, setup_logging
+
 pn.extension()
 
 
@@ -66,3 +68,56 @@ monitor = pn.Row(
     active_user_count,
     sizing_mode="stretch_width"
 )
+
+setup_logging()
+
+log = pn.Column(sizing_mode="stretch_both")
+
+def _get_active_index():
+    if len(log) == 0:
+        return 0
+    tabs_widget = log[0]
+    return getattr(tabs_widget, "active", 0)
+
+def refresh_tabs():
+    buffers = list_buffers(
+        skip_routes=["ephys_monitor_app", "ephys_launcher_app"],
+    )
+    prev_active = _get_active_index()
+    if not buffers:
+        log[:] = [pn.pane.Markdown("No logs yet.", sizing_mode="stretch_both")]
+        return
+
+    tabs = []
+    for key, widget in buffers.items():
+        route, session_id = key
+        title = f"{route} | {str(session_id)[:8]}"
+
+        close_btn = pn.widgets.Button(name="Close", button_type="danger", width=80)
+
+        def _close(event, key=key):
+            remove_buffer(key)
+            refresh_tabs()
+
+        close_btn.on_click(_close)
+
+        tab_body = pn.Column(
+            pn.Row(pn.pane.Markdown(f"**{title}**"), pn.Spacer(), close_btn),
+            widget,
+            sizing_mode="stretch_both",
+        )
+        tabs.append((title, tab_body))
+
+    tabs_widget = pn.Tabs(*tabs, sizing_mode="stretch_both")
+    if tabs:
+        tabs_widget.active = min(prev_active, len(tabs) - 1)
+
+    log[:] = [tabs_widget]
+
+
+pn.state.add_periodic_callback(refresh_tabs, period=2000)
+refresh_tabs()
+
+app = pn.Column(monitor, log, sizing_mode="stretch_both")
+
+app.servable(title="AIND Ephys Monitor")

--- a/src/aind_ephys_portal/ephys_monitor_app.py
+++ b/src/aind_ephys_portal/ephys_monitor_app.py
@@ -9,8 +9,8 @@ pn.extension()
 # --- Memory info ---
 def get_mem_info():
     mem = psutil.virtual_memory()
-    used_gb = mem.used / (1024 ** 3)
-    total_gb = mem.total / (1024 ** 3)
+    used_gb = mem.used / (1024**3)
+    total_gb = mem.total / (1024**3)
     percent = mem.percent
     return used_gb, total_gb, percent
 
@@ -69,7 +69,7 @@ def update_sessions_summary(sessions):
 
     # Count sessions per route
     route_counts = {}
-    for (route, _) in sessions.keys():
+    for route, _ in sessions.keys():
         route_counts[route] = route_counts.get(route, 0) + 1
 
     badges = []
@@ -101,13 +101,16 @@ def update_sessions_summary(sessions):
 
 # --- Log viewer ---
 log_container = pn.Column(sizing_mode="stretch_both")
-_log_panes = {}        # key → pn.pane.HTML  (the log content pane)
-_log_contents = {}     # key → last content string  (skip no-op updates)
-_tab_bodies = {}       # key → pn.Column  (the whole tab body)
-_tabs_widget = None    # the single Tabs widget we keep alive
-_prev_keys_order = []  # ordered list of keys to detect session changes
+_log_widgets = {}  # cache TextAreaInput widgets per (route, session_id)
 
 SKIP_ROUTES = ["ephys_monitor_app"]
+
+
+def _get_active_tab():
+    if len(log_container) == 0:
+        return 0
+    widget = log_container[0]
+    return getattr(widget, "active", 0)
 
 
 def _make_clear_callback(route, session_id, path):
@@ -115,11 +118,11 @@ def _make_clear_callback(route, session_id, path):
         try:
             path.write_text("")
             key = (route, session_id)
-            if key in _log_panes:
-                _log_panes[key].object = _make_log_pre("")
-                _log_contents[key] = ""
+            if key in _log_widgets:
+                _log_widgets[key].value = ""
         except Exception as e:
             print(f"Error clearing log: {e}")
+
     return _clear
 
 
@@ -128,147 +131,85 @@ def _make_delete_callback(route, session_id):
         try:
             remove_session(route=route, session_id=session_id)
             key = (route, session_id)
-            _log_panes.pop(key, None)
-            _log_contents.pop(key, None)
-            _tab_bodies.pop(key, None)
+            if key in _log_widgets:
+                del _log_widgets[key]
             refresh_log_tabs()
         except Exception as e:
             print(f"Error deleting log: {e}")
+
     return _delete
 
 
-def _make_log_pre(content):
-    """Wrap log content in a scrollable <pre>.
-
-    We do NOT use an inline <script> because Panel doesn't re-execute
-    scripts when updating .object.  Instead we keep the user's current
-    scroll position by *only* updating the text content of the <pre> via
-    Panel, and never recreating the widget.
-
-    Auto-scroll to bottom is achieved via an `afterUpdate` JS callback
-    on the pane (see _make_log_pane).
-    """
-    import html as html_mod
-    escaped = html_mod.escape(content)
-    return (
-        f'<pre class="log-pre" style="'
-        f"white-space: pre-wrap;"
-        f"word-wrap: break-word;"
-        f"overflow-y: auto;"
-        f"max-height: 500px;"
-        f"min-height: 200px;"
-        f"background: #f5f5f5;"
-        f"padding: 8px;"
-        f"font-size: 12px;"
-        f"border: 1px solid #ccc;"
-        f"border-radius: 4px;"
-        f'">{escaped}</pre>'
-    )
-
-
-def _make_log_pane(content):
-    """Create a log HTML pane with a JS callback that auto-scrolls."""
-    pane = pn.pane.HTML(_make_log_pre(content), sizing_mode="stretch_both")
-    # Whenever the HTML object changes, scroll the <pre> to the bottom.
-    # Panel exposes a jscallback on 'object' which fires client-side
-    # after the new HTML is rendered.
-    try:
-        pane.jscallback(
-            object="""
-            setTimeout(function() {
-                var el = cb_obj.el;
-                if (!el) return;
-                var pre = el.querySelector('.log-pre');
-                if (pre) { pre.scrollTop = pre.scrollHeight; }
-            }, 50);
-            """
-        )
-    except Exception:
-        pass  # jscallback not available in all Panel versions
-    return pane
-
-
 def refresh_log_tabs():
-    global _tabs_widget, _prev_keys_order
-
     all_sessions = list_sessions()
     update_sessions_summary(all_sessions)
     log_sessions = list_sessions(skip_routes=SKIP_ROUTES)
 
     if not log_sessions:
-        _tabs_widget = None
-        _prev_keys_order = []
-        log_container[:] = [pn.pane.Markdown("No active sessions.", sizing_mode="stretch_both")]
+        log_container[:] = [pn.pane.Markdown("_No log sessions._")]
         return
 
-    current_keys = list(log_sessions.keys())
-    structure_changed = (current_keys != _prev_keys_order)
+    prev_active = _get_active_tab()
 
-    # --- Update content of each session (cheap: only touches .object) ---
-    for key, path in log_sessions.items():
-        route, session_id = key
+    tabs = []
+    for (route, session_id), path in log_sessions.items():
+        title = f"{route} | {str(session_id)[:8]}"
+
+        # Read log content from file
         content = ""
         try:
             content = path.read_text()
         except Exception:
             content = "(could not read log)"
 
-        if key not in _log_panes:
-            # First time seeing this session
-            _log_panes[key] = _make_log_pane(content)
-            _log_contents[key] = content
+        # Compute height: ~16px per line, min 200, no max
+        n_lines = max(content.count("\n") + 1, 10)
+        height = max(200, n_lines * 16 + 20)
 
-            title = f"{route} | {str(session_id)[:8]}"
-            clear_btn = pn.widgets.Button(name="🗑️ Clear", button_type="warning", width=100)
-            clear_btn.on_click(_make_clear_callback(route, session_id, path))
-            delete_btn = pn.widgets.Button(name="❌ Delete", button_type="danger", width=100)
-            delete_btn.on_click(_make_delete_callback(route, session_id))
-
-            _tab_bodies[key] = pn.Column(
-                pn.Row(
-                    pn.pane.Markdown(f"**{title}**"),
-                    pn.Spacer(),
-                    clear_btn,
-                    delete_btn,
-                ),
-                _log_panes[key],
-                sizing_mode="stretch_both",
+        # Reuse or create widget
+        key = (route, session_id)
+        if key not in _log_widgets:
+            _log_widgets[key] = pn.widgets.TextAreaInput(
+                value=content,
+                disabled=True,
+                sizing_mode="stretch_width",
+                height=height,
+                stylesheets=[":host textarea { font-size: 12px; font-family: monospace; }"],
             )
-            structure_changed = True
         else:
-            # Only update the HTML text if it actually changed
-            if content != _log_contents.get(key):
-                _log_panes[key].object = _make_log_pre(content)
-                _log_contents[key] = content
+            _log_widgets[key].value = content
+            _log_widgets[key].height = height
 
-    # --- Clean up stale sessions ---
-    active_keys = set(current_keys)
-    for key in list(_log_panes.keys()):
+        # Action buttons
+        clear_btn = pn.widgets.Button(name="🗑️ Clear", button_type="warning", width=100)
+        clear_btn.on_click(_make_clear_callback(route, session_id, path))
+
+        delete_btn = pn.widgets.Button(name="❌ Delete", button_type="danger", width=100)
+        delete_btn.on_click(_make_delete_callback(route, session_id))
+
+        tab_body = pn.Column(
+            pn.Row(
+                pn.pane.Markdown(f"**{title}**"),
+                pn.Spacer(),
+                clear_btn,
+                delete_btn,
+            ),
+            _log_widgets[key],
+            sizing_mode="stretch_both",
+        )
+        tabs.append((title, tab_body))
+
+    # Clean up stale widgets
+    active_keys = set(log_sessions.keys())
+    for key in list(_log_widgets.keys()):
         if key not in active_keys:
-            _log_panes.pop(key, None)
-            _log_contents.pop(key, None)
-            _tab_bodies.pop(key, None)
-            structure_changed = True
+            del _log_widgets[key]
 
-    # --- Rebuild the Tabs widget only when sessions come/go ---
-    if structure_changed or _tabs_widget is None:
-        prev_active = 0
-        if _tabs_widget is not None:
-            prev_active = getattr(_tabs_widget, "active", 0)
+    tabs_widget = pn.Tabs(*tabs, sizing_mode="stretch_both", dynamic=True)
+    if tabs:
+        tabs_widget.active = min(prev_active, len(tabs) - 1)
 
-        tabs = []
-        for key in current_keys:
-            route, session_id = key
-            title = f"{route} | {str(session_id)[:8]}"
-            tabs.append((title, _tab_bodies[key]))
-
-        _tabs_widget = pn.Tabs(*tabs, sizing_mode="stretch_both")
-        if tabs:
-            _tabs_widget.active = min(prev_active, len(tabs) - 1)
-
-        log_container[:] = [_tabs_widget]
-
-    _prev_keys_order = current_keys
+    log_container[:] = [tabs_widget]
 
 
 pn.state.add_periodic_callback(refresh_log_tabs, period=2000)

--- a/src/aind_ephys_portal/ephys_monitor_app.py
+++ b/src/aind_ephys_portal/ephys_monitor_app.py
@@ -1,7 +1,7 @@
-import panel as pn
 import psutil
+import panel as pn
 
-from aind_ephys_portal.panel.logging import list_buffers, remove_buffer, setup_logging
+from aind_ephys_portal.panel.logging import list_sessions, remove_session
 
 pn.extension()
 
@@ -9,115 +9,282 @@ pn.extension()
 # --- Memory info ---
 def get_mem_info():
     mem = psutil.virtual_memory()
-    total_gb = mem.total / 1e9
-    used_gb = mem.used / 1e9
-    return used_gb, total_gb, mem.percent
+    used_gb = mem.used / (1024 ** 3)
+    total_gb = mem.total / (1024 ** 3)
+    percent = mem.percent
+    return used_gb, total_gb, percent
 
 
-# --- Progress indicator ---
+# --- CPU info ---
+def get_cpu_percent():
+    return psutil.cpu_percent(interval=None)
+
+
+# --- Progress indicators ---
 used_gb, total_gb, percent = get_mem_info()
 
-ram_monitor = pn.widgets.indicators.Progress(
-    name="Memory Usage",
-    value=int(used_gb),
-    max=int(total_gb),
-    bar_color="success" if percent < 70 else "warning" if percent < 90 else "danger",
-    width=400,
-    height=30,
-)
-
-cpu_monitor = pn.widgets.indicators.Progress(
-    name="CPU Usage",
-    value=int(psutil.cpu_percent()),
+ram_usage_label = pn.pane.Markdown(f"🧠 RAM Usage", styles={"font-weight": "bold"})
+ram_monitor = pn.indicators.Progress(
+    name="RAM",
+    value=int(percent),
     max=100,
-    bar_color="success" if psutil.cpu_percent() < 70 else "warning" if psutil.cpu_percent() < 90 else "danger",
-    width=400,
-    height=30,
+    sizing_mode="stretch_width",
+    bar_color="success" if percent < 70 else ("warning" if percent < 90 else "danger"),
+)
+
+cpu_usage_label = pn.pane.Markdown(f"🖥️ CPU Usage", styles={"font-weight": "bold"})
+cpu_monitor = pn.indicators.Progress(
+    name="CPU",
+    value=int(get_cpu_percent()),
+    max=100,
+    sizing_mode="stretch_width",
+    bar_color="success",
 )
 
 
-# --- Periodic update ---
-def update_usage():
+def update_monitors():
     used_gb, total_gb, percent = get_mem_info()
-    ram_monitor.value = int(used_gb)
-    ram_monitor.bar_color = "success" if percent < 70 else "warning" if percent < 90 else "danger"
-    cpu_percent = psutil.cpu_percent()
-    cpu_monitor.value = int(cpu_percent)
-    cpu_monitor.bar_color = "success" if cpu_percent < 70 else "warning" if cpu_percent < 90 else "danger"
+    ram_monitor.value = int(percent)
+    ram_monitor.bar_color = "success" if percent < 70 else ("warning" if percent < 90 else "danger")
+    ram_usage_label.object = f"🧠 RAM Usage ({used_gb:.1f} / {total_gb:.1f} GB)"
 
-pn.state.add_periodic_callback(update_usage, period=2000)
-
-ram_usage_label = pn.widgets.StaticText(value="🐏 RAM Usage", height=30)
-cpu_usage_label = pn.widgets.StaticText(value="🖥️ CPU Usage", height=30)
-active_user_count_label = pn.widgets.StaticText(value="🧑‍🔬 Active Users", height=30)
-active_user_count = pn.widgets.StaticText(value="0", height=30)
+    cpu = get_cpu_percent()
+    cpu_monitor.value = int(cpu)
+    cpu_monitor.bar_color = "success" if cpu < 70 else ("warning" if cpu < 90 else "danger")
+    cpu_usage_label.object = f"🖥️ CPU Usage ({cpu:.0f}%)"
 
 
-def update_user_count():
-    active_user_count.value = str(len(pn.state.active_sessions))
+pn.state.add_periodic_callback(update_monitors, period=2000)
 
 
-pn.state.add_periodic_callback(update_user_count, period=2000)
+# --- Active sessions summary ---
+sessions_summary = pn.Row(sizing_mode="stretch_width")
 
-monitor = pn.Row(
-    ram_usage_label,
-    ram_monitor,
-    cpu_usage_label,
-    cpu_monitor,
-    active_user_count_label, 
-    active_user_count,
-    sizing_mode="stretch_width"
-)
 
-setup_logging()
-
-log = pn.Column(sizing_mode="stretch_both")
-
-def _get_active_index():
-    if len(log) == 0:
-        return 0
-    tabs_widget = log[0]
-    return getattr(tabs_widget, "active", 0)
-
-def refresh_tabs():
-    buffers = list_buffers(
-        skip_routes=["ephys_monitor_app", "ephys_launcher_app"],
-    )
-    prev_active = _get_active_index()
-    if not buffers:
-        log[:] = [pn.pane.Markdown("No logs yet.", sizing_mode="stretch_both")]
+def update_sessions_summary(sessions):
+    """Update the active sessions summary row with per-route counts."""
+    if not sessions:
+        sessions_summary[:] = [pn.pane.Markdown("No active sessions.")]
         return
 
-    tabs = []
-    for key, widget in buffers.items():
-        route, session_id = key
-        title = f"{route} | {str(session_id)[:8]}"
+    # Count sessions per route
+    route_counts = {}
+    for (route, _) in sessions.keys():
+        route_counts[route] = route_counts.get(route, 0) + 1
 
-        close_btn = pn.widgets.Button(name="Close", button_type="danger", width=80)
-
-        def _close(event, key=key):
-            remove_buffer(key)
-            refresh_tabs()
-
-        close_btn.on_click(_close)
-
-        tab_body = pn.Column(
-            pn.Row(pn.pane.Markdown(f"**{title}**"), pn.Spacer(), close_btn),
-            widget,
-            sizing_mode="stretch_both",
+    badges = []
+    for route, count in sorted(route_counts.items()):
+        badge = pn.pane.Markdown(
+            f"**{route}**: {count}",
+            styles={
+                "background": "#e8f4fd",
+                "border-radius": "8px",
+                "padding": "6px 14px",
+                "margin": "4px",
+                "border": "1px solid #2A7DE1",
+            },
         )
-        tabs.append((title, tab_body))
+        badges.append(badge)
 
-    tabs_widget = pn.Tabs(*tabs, sizing_mode="stretch_both")
-    if tabs:
-        tabs_widget.active = min(prev_active, len(tabs) - 1)
+    total = pn.pane.Markdown(
+        f"**Total: {sum(route_counts.values())}**",
+        styles={
+            "background": "#d4edda",
+            "border-radius": "8px",
+            "padding": "6px 14px",
+            "margin": "4px",
+            "border": "1px solid #1D8649",
+        },
+    )
+    sessions_summary[:] = [total] + badges
 
-    log[:] = [tabs_widget]
+
+# --- Log viewer ---
+log_container = pn.Column(sizing_mode="stretch_both")
+_log_panes = {}        # key → pn.pane.HTML  (the log content pane)
+_log_contents = {}     # key → last content string  (skip no-op updates)
+_tab_bodies = {}       # key → pn.Column  (the whole tab body)
+_tabs_widget = None    # the single Tabs widget we keep alive
+_prev_keys_order = []  # ordered list of keys to detect session changes
+
+SKIP_ROUTES = ["ephys_monitor_app"]
 
 
-pn.state.add_periodic_callback(refresh_tabs, period=2000)
-refresh_tabs()
+def _make_clear_callback(route, session_id, path):
+    def _clear(event):
+        try:
+            path.write_text("")
+            key = (route, session_id)
+            if key in _log_panes:
+                _log_panes[key].object = _make_log_pre("")
+                _log_contents[key] = ""
+        except Exception as e:
+            print(f"Error clearing log: {e}")
+    return _clear
 
-app = pn.Column(monitor, log, sizing_mode="stretch_both")
+
+def _make_delete_callback(route, session_id):
+    def _delete(event):
+        try:
+            remove_session(route=route, session_id=session_id)
+            key = (route, session_id)
+            _log_panes.pop(key, None)
+            _log_contents.pop(key, None)
+            _tab_bodies.pop(key, None)
+            refresh_log_tabs()
+        except Exception as e:
+            print(f"Error deleting log: {e}")
+    return _delete
+
+
+def _make_log_pre(content):
+    """Wrap log content in a scrollable <pre>.
+
+    We do NOT use an inline <script> because Panel doesn't re-execute
+    scripts when updating .object.  Instead we keep the user's current
+    scroll position by *only* updating the text content of the <pre> via
+    Panel, and never recreating the widget.
+
+    Auto-scroll to bottom is achieved via an `afterUpdate` JS callback
+    on the pane (see _make_log_pane).
+    """
+    import html as html_mod
+    escaped = html_mod.escape(content)
+    return (
+        f'<pre class="log-pre" style="'
+        f"white-space: pre-wrap;"
+        f"word-wrap: break-word;"
+        f"overflow-y: auto;"
+        f"max-height: 500px;"
+        f"min-height: 200px;"
+        f"background: #f5f5f5;"
+        f"padding: 8px;"
+        f"font-size: 12px;"
+        f"border: 1px solid #ccc;"
+        f"border-radius: 4px;"
+        f'">{escaped}</pre>'
+    )
+
+
+def _make_log_pane(content):
+    """Create a log HTML pane with a JS callback that auto-scrolls."""
+    pane = pn.pane.HTML(_make_log_pre(content), sizing_mode="stretch_both")
+    # Whenever the HTML object changes, scroll the <pre> to the bottom.
+    # Panel exposes a jscallback on 'object' which fires client-side
+    # after the new HTML is rendered.
+    try:
+        pane.jscallback(
+            object="""
+            setTimeout(function() {
+                var el = cb_obj.el;
+                if (!el) return;
+                var pre = el.querySelector('.log-pre');
+                if (pre) { pre.scrollTop = pre.scrollHeight; }
+            }, 50);
+            """
+        )
+    except Exception:
+        pass  # jscallback not available in all Panel versions
+    return pane
+
+
+def refresh_log_tabs():
+    global _tabs_widget, _prev_keys_order
+
+    all_sessions = list_sessions()
+    update_sessions_summary(all_sessions)
+    log_sessions = list_sessions(skip_routes=SKIP_ROUTES)
+
+    if not log_sessions:
+        _tabs_widget = None
+        _prev_keys_order = []
+        log_container[:] = [pn.pane.Markdown("No active sessions.", sizing_mode="stretch_both")]
+        return
+
+    current_keys = list(log_sessions.keys())
+    structure_changed = (current_keys != _prev_keys_order)
+
+    # --- Update content of each session (cheap: only touches .object) ---
+    for key, path in log_sessions.items():
+        route, session_id = key
+        content = ""
+        try:
+            content = path.read_text()
+        except Exception:
+            content = "(could not read log)"
+
+        if key not in _log_panes:
+            # First time seeing this session
+            _log_panes[key] = _make_log_pane(content)
+            _log_contents[key] = content
+
+            title = f"{route} | {str(session_id)[:8]}"
+            clear_btn = pn.widgets.Button(name="🗑️ Clear", button_type="warning", width=100)
+            clear_btn.on_click(_make_clear_callback(route, session_id, path))
+            delete_btn = pn.widgets.Button(name="❌ Delete", button_type="danger", width=100)
+            delete_btn.on_click(_make_delete_callback(route, session_id))
+
+            _tab_bodies[key] = pn.Column(
+                pn.Row(
+                    pn.pane.Markdown(f"**{title}**"),
+                    pn.Spacer(),
+                    clear_btn,
+                    delete_btn,
+                ),
+                _log_panes[key],
+                sizing_mode="stretch_both",
+            )
+            structure_changed = True
+        else:
+            # Only update the HTML text if it actually changed
+            if content != _log_contents.get(key):
+                _log_panes[key].object = _make_log_pre(content)
+                _log_contents[key] = content
+
+    # --- Clean up stale sessions ---
+    active_keys = set(current_keys)
+    for key in list(_log_panes.keys()):
+        if key not in active_keys:
+            _log_panes.pop(key, None)
+            _log_contents.pop(key, None)
+            _tab_bodies.pop(key, None)
+            structure_changed = True
+
+    # --- Rebuild the Tabs widget only when sessions come/go ---
+    if structure_changed or _tabs_widget is None:
+        prev_active = 0
+        if _tabs_widget is not None:
+            prev_active = getattr(_tabs_widget, "active", 0)
+
+        tabs = []
+        for key in current_keys:
+            route, session_id = key
+            title = f"{route} | {str(session_id)[:8]}"
+            tabs.append((title, _tab_bodies[key]))
+
+        _tabs_widget = pn.Tabs(*tabs, sizing_mode="stretch_both")
+        if tabs:
+            _tabs_widget.active = min(prev_active, len(tabs) - 1)
+
+        log_container[:] = [_tabs_widget]
+
+    _prev_keys_order = current_keys
+
+
+pn.state.add_periodic_callback(refresh_log_tabs, period=2000)
+refresh_log_tabs()
+
+
+# --- App layout ---
+app = pn.Column(
+    pn.pane.Markdown("## AIND Ephys Monitor"),
+    pn.Row(ram_usage_label, ram_monitor),
+    pn.Row(cpu_usage_label, cpu_monitor),
+    pn.pane.Markdown("## Active Sessions"),
+    sessions_summary,
+    pn.pane.Markdown("## Session Logs"),
+    log_container,
+    sizing_mode="stretch_both",
+)
 
 app.servable(title="AIND Ephys Monitor")

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -1,13 +1,12 @@
-import sys
+import psutil
 import param
-import boto3
 import time
+import gc
+import ctypes
 
 import panel as pn
 
 pn.extension("tabulator", "gridstack")
-
-from aind_ephys_portal.monitor import monitor
 
 
 from spikeinterface_gui import run_mainwindow
@@ -18,7 +17,8 @@ from spikeinterface.core.core_tools import extractor_dict_iterator, set_value_in
 from spikeinterface.curation import validate_curation_dict
 from spikeinterface_gui.curation_tools import empty_curation_data, default_label_definitions
 
-from .utils import Tee
+from aind_ephys_portal.panel.logging import setup_logging, local_log_context
+from aind_ephys_portal.panel.utils import Tee
 
 
 displayed_unit_properties = ["decoder_label", "default_qc", "firing_rate", "y", "snr", "amplitude_median", "isi_violation_ratio"]
@@ -38,10 +38,9 @@ default_curation_dict = {
 
 help_txt = """
 ## Usage
-Sorting Analyzer not loaded. Follow the steps below to launch the SpikeInterface GUI:
-1. Enter the path to the SpikeInterface analyzer Zarr file.
-2. (Optional) Enter the path to the processed recording folder.
-3. Click "Launch!" to start the SpikeInterface GUI.
+Sorting Analyzer not loaded. Embed the `analyzer_path` parameter in the URL 
+(and optionally the `recording_path` parameter) to launch the GUI. For example:
+ephys.allenneuraldymamics.org/ephys_gui_app?analyzer_path="/path/to/analyzer.zarr"&recording_path="/path/to/recording.zarr"
 """
 
 # Define the layout for the AIND Ephys GUI
@@ -63,99 +62,94 @@ class EphysGuiView(param.Parameterized):
         """Construct the QCPanel object"""
         super().__init__(**params)
 
-        # Setup minimal record information from DocDB
+        setup_logging()
+
         self.analyzer_path = analyzer_path
         self.recording_path = recording_path
         self.analyzer = None
-
-        self.analyzer_input = pn.widgets.TextInput(
-            name="Analyzer path", value=self.analyzer_path, height=50, sizing_mode="stretch_width"
-        )
-        self.recording_input = pn.widgets.TextInput(
-            name="Recording path (optional)", value=self.recording_path, height=50, sizing_mode="stretch_width"
-        )
-        self.launch_button = pn.widgets.Button(
-            name="Launch!", button_type="primary", height=50, sizing_mode="stretch_width"
-        )
+        self._cleanup_registered = False
 
         self.spinner = pn.indicators.LoadingSpinner(value=True, sizing_mode="stretch_width")
-        self.log_output_text = pn.widgets.TextAreaInput(value="", sizing_mode="stretch_both")
-        clear_log_button = pn.widgets.Button(name="Clear Log", button_type="warning", sizing_mode="stretch_width")
-        clear_log_button.on_click(self._clear_log)
-        self.log_output = pn.Column(self.log_output_text, clear_log_button, sizing_mode="stretch_both")
-
-        original_stdout = sys.stdout
-        sys.stdout = Tee(original_stdout, self.log_output_text)
-        original_stderr = sys.stderr
-        sys.stderr = Tee(original_stderr, self.log_output_text)
-
+        self.log_output = pn.widgets.TextAreaInput(value="", sizing_mode="stretch_both")
         self.loading_banner = pn.Row(self.spinner, self.log_output, sizing_mode="stretch_both")
 
-        self.launcher_panel = pn.Row(
-            self.analyzer_input,
-            self.recording_input,
-            self.launch_button,
-            sizing_mode="stretch_width",
-        )
-        self.monitor_panel = pn.Column(
-            self.launcher_panel,
-            monitor,
-            sizing_mode="stretch_both",
-        )
-
-        # Setup event handlers
-        self.analyzer_input.param.watch(self.update_values, "value")
-        self.recording_input.param.watch(self.update_values, "value")
-        self.launch_button.on_click(self.on_click)
-
-        empty_widget = pn.pane.Markdown(" ", height=1)
+        self.win = None
         if self.analyzer_path != "":
-            # Create initial layout
             self.layout = pn.Column(
-                empty_widget,
                 self._create_main_window(),
                 sizing_mode="stretch_both",
             )
-            # # # Schedule initialization to run after UI is rendered
             def delayed_init():
                 self._initialize()
-                return False  # Don't repeat the callback
-            pn.state.add_periodic_callback(delayed_init, period=1500, count=1)
+                return False
+            self._init_cb = pn.state.add_periodic_callback(delayed_init, period=1500, count=1)
         else:
             self.layout = pn.Column(
-                self.launcher_panel,
-                self._create_main_window(),
+                pn.pane.Markdown(help_txt, sizing_mode="stretch_both"),
                 sizing_mode="stretch_both",
             )
 
+    def _register_cleanup(self):
+        """Register cleanup on the current document. Must be called from within the session."""
+        if self._cleanup_registered:
+            return
+        doc = pn.state.curdoc
+        if doc is not None and hasattr(doc, "on_session_destroyed"):
+            def _on_destroy(session_context, view=self):
+                view.cleanup()
+            doc.on_session_destroyed(_on_destroy)
+            self._cleanup_registered = True
+            print(f"[GUI] Cleanup registered on doc {id(doc)}")
+
     def _initialize(self):
-        self.layout[1] = self.loading_banner
-        self.log_output_text.value = ""
-        if self.analyzer_input.value != "":
-            t_start = time.perf_counter()
-            print(
-                f"Initializing Ephys GUI for:\nAnalyzer path: {self.analyzer_path}\nRecording path: {self.recording_path}"
-            )
-            self._initialize_analyzer()
-            if self.recording_path != "":
-                self._set_processed_recording()
-            self.win = self._create_main_window()
-            self.layout[1] = self.win
-            print("Ephys GUI initialized successfully!")
-            t_stop = time.perf_counter()
-            print(f"Initialization time: {t_stop - t_start:.2f} seconds")
-        else:
-            print("Analyzer path is empty. Please provide a valid path.")
+        # Register cleanup HERE — the document is now bound to this GUI session
+        self._register_cleanup()
+
+        self.layout[0] = self.loading_banner
+        self.log_output.value = ""
+        with local_log_context(self.log_output):
+            error = None
+            if self.analyzer_path != "":
+                try:
+                    t_start = time.perf_counter()
+                    initial_mem = psutil.virtual_memory()
+                    total_ram = initial_mem.total / (1024 ** 3)
+                    current_ram_usage = initial_mem.used / (1024 ** 3)
+                    print(f"Initializing Ephys GUI")
+                    print(f"\nRAM Usage before initialization: {current_ram_usage:.2f} / {total_ram:.2f} GB\n")
+
+                    print(f"\nLoading with the following paths:")
+                    print(f"Analyzer path:\n{self.analyzer_path}\nRecording path:\n{self.recording_path}")
+                    self._initialize_analyzer()
+                    if self.recording_path != "":
+                        self._set_processed_recording()
+                    win = self._create_main_window()
+                    self.layout[0] = win
+                    print("\nEphys GUI initialized successfully!")
+                    t_stop = time.perf_counter()
+                    print(f"Initialization time: {t_stop - t_start:.2f} seconds")
+
+                    final_mem = psutil.virtual_memory()
+                    final_ram_usage = final_mem.used / (1024 ** 3)
+                    print(f"\nRAM Usage after initialization: {final_ram_usage:.2f} / {total_ram:.2f} GB\n")
+                except Exception as e:
+                    error = e
+            else:
+                print("Analyzer path is empty. Please provide a valid path.")
+
+            if error is not None:
+                print(f"Error during initialization: {error}")
+                self.layout[0] = pn.pane.Markdown(f"⚠️ Error during initialization: {error}", sizing_mode="stretch_both")
 
     def _initialize_analyzer(self):
         if not self.analyzer_path.endswith((".zarr", ".zarr/")):
             raise ValueError("Only Zarr files are supported for now.")
-        print(f"Loading analyzer from {self.analyzer_path}...")
+        print(f"Loading analyzer...")
         self.analyzer = si.load(self.analyzer_path, load_extensions=False)
         print(f"Analyzer loaded: {self.analyzer}")
 
     def _set_processed_recording(self):
-        print(f"Loading processed recording from {self.recording_path}")
+        print(f"Loading processed recording...")
         analyzer_root = self.analyzer._get_zarr_root(mode="r")
         recording_root = analyzer_root["recording"]
         recording_dict = recording_root[0]
@@ -197,32 +191,74 @@ class EphysGuiView(param.Parameterized):
                 curation_dict=curation_dict,
                 mode="web",
                 start_app=False,
+                # for testing
+                skip_extensions=["waveforms", "principal_components"],
                 panel_window_servable=False,
                 verbose=True,
                 layout=aind_layout
             )
-            self.log_output.value = ""
-            tabs = pn.Tabs(
-                ("GUI", win.main_layout),
-                ("Launch/Monitor", self.monitor_panel),
-                ("Log", self.log_output),
-                tabs_location="below",
-                sizing_mode="stretch_both",
-            )
-            return tabs
+            self.win = win
+            return win.main_layout
         else:
             return pn.pane.Markdown(help_txt, sizing_mode="stretch_both")
 
-    def update_values(self, event):
-        self.analyzer_path = self.analyzer_input.value
-        self.recording_path = self.recording_input.value
+    def cleanup(self):
+        """Release resources when the session is closed."""
+        print("Cleaning up Ephys GUI resources...")
+        initial_mem = psutil.virtual_memory()
+        total_ram = initial_mem.total / (1024 ** 3)
+        current_ram_usage = initial_mem.used / (1024 ** 3)
+        print(f"\nRAM Usage before cleanup: {current_ram_usage:.2f} / {total_ram:.2f} GB\n")
 
-    def _clear_log(self, event):
-        self.log_output_text.value = ""
+        # 1) Release GUI controller references
+        if self.win is not None:
+            del self.win
 
-    def on_click(self, event):
-        print("Launching SpikeInterface GUI!")
-        self._initialize()
+        # 2) Close zarr store explicitly
+        if self.analyzer is not None:
+            # Try to close the underlying zarr store
+            zarr_root = getattr(self.analyzer, "sorting_analyzer", None) or self.analyzer
+            store = getattr(zarr_root, "_root", None)
+            if store is not None:
+                inner_store = getattr(store, "store", None)
+                if inner_store is not None and hasattr(inner_store, "close"):
+                    inner_store.close()
+                    print("Zarr store closed.")
+            self.analyzer = None
+            print("Analyzer resources released.")
+
+        # 3) Clear layout references
+        if self._init_cb is not None:
+            self._init_cb.stop()
+            self._init_cb = None
+        self.layout = None
+        self.log_output = None
+        self.spinner = None
+        self.loading_banner = None
+
+        # 4) Force garbage collection (two passes for ref cycles)
+        gc.collect()
+        gc.collect()
+
+        # 5) Force glibc to return freed memory to OS
+        # try:
+        #     ctypes.CDLL("libc.so.6").malloc_trim(0)
+        #     print("malloc_trim: freed memory returned to OS.")
+        # except Exception as e:
+        #     print(f"malloc_trim failed: {e}")
+
+        final_mem = psutil.virtual_memory()
+        current_ram_usage = final_mem.used / (1024 ** 3)
+        print(f"\nRAM Usage after cleanup: {current_ram_usage:.2f} / {total_ram:.2f} GB\n")
+
+
+        # Debug: compare RSS vs OS-reported used
+        import os
+        process = psutil.Process(os.getpid())
+        rss = process.memory_info().rss / 1024**2
+        print(f"\nProcess RSS: {rss:.1f} MB")
+        print(f"OS used (includes page cache): {psutil.virtual_memory().used / 1024**2:.1f} MB")
+        print(f"OS available: {psutil.virtual_memory().available / 1024**2:.1f} MB")
 
     def panel(self):
         """Return the panel layout"""

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -10,15 +10,12 @@ pn.extension("tabulator", "gridstack")
 
 
 from spikeinterface_gui import run_mainwindow
-from spikeinterface_gui.launcher import instantiate_analyzer_and_recording
 
 import spikeinterface as si
 from spikeinterface.core.core_tools import extractor_dict_iterator, set_value_in_extractor_dict
 from spikeinterface.curation import validate_curation_dict
-from spikeinterface_gui.curation_tools import empty_curation_data, default_label_definitions
 
 from aind_ephys_portal.panel.logging import setup_logging, local_log_context
-from aind_ephys_portal.panel.utils import Tee
 
 
 displayed_unit_properties = ["decoder_label", "default_qc", "firing_rate", "y", "snr", "amplitude_median", "isi_violation_ratio"]
@@ -107,16 +104,19 @@ class EphysGuiView(param.Parameterized):
 
         self.layout[0] = self.loading_banner
         self.log_output.value = ""
+
+        initial_mem = psutil.virtual_memory()
+        total_ram = initial_mem.total / (1024 ** 3)
+        current_ram_usage = initial_mem.used / (1024 ** 3)
+        available_ram = initial_mem.available / (1024 ** 3)
+        print(f"\nRAM Usage before initialization:")
+        print(f"\tUsed: {current_ram_usage:.2f}/{total_ram:.2f} GB\n\tAvailable: {available_ram:.2f}/{total_ram:.2f} GB\n")
         with local_log_context(self.log_output):
             error = None
             if self.analyzer_path != "":
                 try:
                     t_start = time.perf_counter()
-                    initial_mem = psutil.virtual_memory()
-                    total_ram = initial_mem.total / (1024 ** 3)
-                    current_ram_usage = initial_mem.used / (1024 ** 3)
                     print(f"Initializing Ephys GUI")
-                    print(f"\nRAM Usage before initialization: {current_ram_usage:.2f} / {total_ram:.2f} GB\n")
 
                     print(f"\nLoading with the following paths:")
                     print(f"Analyzer path:\n{self.analyzer_path}\nRecording path:\n{self.recording_path}")
@@ -129,9 +129,6 @@ class EphysGuiView(param.Parameterized):
                     t_stop = time.perf_counter()
                     print(f"Initialization time: {t_stop - t_start:.2f} seconds")
 
-                    final_mem = psutil.virtual_memory()
-                    final_ram_usage = final_mem.used / (1024 ** 3)
-                    print(f"\nRAM Usage after initialization: {final_ram_usage:.2f} / {total_ram:.2f} GB\n")
                 except Exception as e:
                     error = e
             else:
@@ -140,6 +137,12 @@ class EphysGuiView(param.Parameterized):
             if error is not None:
                 print(f"Error during initialization: {error}")
                 self.layout[0] = pn.pane.Markdown(f"⚠️ Error during initialization: {error}", sizing_mode="stretch_both")
+            else:
+                final_mem = psutil.virtual_memory()
+                final_ram_usage = final_mem.used / (1024 ** 3)
+                final_ram_available = final_mem.available / (1024 ** 3)
+                print(f"\nRAM Usage after initialization:")
+                print(f"\tUsed: {final_ram_usage:.2f}/{total_ram:.2f} GB\n\tAvailable: {final_ram_available:.2f}/{total_ram:.2f} GB\n")
 
     def _initialize_analyzer(self):
         if not self.analyzer_path.endswith((".zarr", ".zarr/")):

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -2,7 +2,6 @@ import psutil
 import param
 import time
 import gc
-import ctypes
 
 import panel as pn
 
@@ -264,25 +263,11 @@ class EphysGuiView(param.Parameterized):
         gc.collect()
         gc.collect()
 
-        # 5) Force glibc to return freed memory to OS
-        # try:
-        #     ctypes.CDLL("libc.so.6").malloc_trim(0)
-        #     print("malloc_trim: freed memory returned to OS.")
-        # except Exception as e:
-        #     print(f"malloc_trim failed: {e}")
 
         final_mem = psutil.virtual_memory()
         current_ram_usage = final_mem.used / (1024**3)
         print(f"\nRAM Usage after cleanup: {current_ram_usage:.2f} / {total_ram:.2f} GB\n")
 
-        # Debug: compare RSS vs OS-reported used
-        import os
-
-        process = psutil.Process(os.getpid())
-        rss = process.memory_info().rss / 1024**2
-        print(f"\nProcess RSS: {rss:.1f} MB")
-        print(f"OS used (includes page cache): {psutil.virtual_memory().used / 1024**2:.1f} MB")
-        print(f"OS available: {psutil.virtual_memory().available / 1024**2:.1f} MB")
 
     def panel(self):
         """Return the panel layout"""

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -50,8 +50,8 @@ ephys.allenneuraldymamics.org/ephys_gui_app?analyzer_path="/path/to/analyzer.zar
 
 # Define the layout for the AIND Ephys GUI
 aind_layout = dict(
-    zone1=["unitlist", "curation", "merge", "spikelist"],
-    zone2=[],
+    zone1=["curation", "merge", "spikelist"],
+    zone2=["unitlist",],
     zone3=["spikeamplitude", "spikedepth", "spikerate", "trace", "tracemap"],
     zone4=[],
     zone5=["probe"],

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -50,9 +50,9 @@ ephys.allenneuraldymamics.org/ephys_gui_app?analyzer_path="/path/to/analyzer.zar
 
 # Define the layout for the AIND Ephys GUI
 aind_layout = dict(
-    zone1=["curation", "merge", "spikelist"],
-    zone2=["unitlist",],
-    zone3=["spikeamplitude", "spikedepth", "spikerate", "trace", "tracemap"],
+    zone1=["curation", "spikelist"],
+    zone2=["unitlist", "merge"],
+    zone3=["spikeamplitude", "amplitudescalings", "spikedepth", "spikerate", "trace", "tracemap"],
     zone4=[],
     zone5=["probe"],
     zone6=["ndscatter", "similarity"],
@@ -63,7 +63,7 @@ aind_layout = dict(
 
 class EphysGuiView(param.Parameterized):
 
-    def __init__(self, analyzer_path, recording_path, **params):
+    def __init__(self, analyzer_path, recording_path, fast_mode=False, **params):
         """Construct the QCPanel object"""
         super().__init__(**params)
 
@@ -71,6 +71,7 @@ class EphysGuiView(param.Parameterized):
 
         self.analyzer_path = analyzer_path
         self.recording_path = recording_path
+        self.fast_mode = fast_mode
         self.analyzer = None
         self._cleanup_registered = False
 
@@ -203,6 +204,11 @@ class EphysGuiView(param.Parameterized):
                 print(f"Curated dictionary is invalid: {e}")
                 curation_dict = None
 
+            if self.fast_mode:
+                skip_extensions = ["waveforms", "principal_components"]
+            else:
+                skip_extensions = None
+
             win = run_mainwindow(
                 analyzer=self.analyzer,
                 curation=True,
@@ -213,8 +219,7 @@ class EphysGuiView(param.Parameterized):
                 panel_window_servable=False,
                 verbose=True,
                 layout=aind_layout,
-                # UNCOMMENT THIS TO SPEED UP TESTING
-                # skip_extensions=["waveforms", "principal_components"],
+                skip_extensions=skip_extensions,
             )
             self.win = win
             return win.main_layout

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -18,14 +18,22 @@ from spikeinterface.curation import validate_curation_dict
 from aind_ephys_portal.panel.logging import setup_logging, local_log_context
 
 
-displayed_unit_properties = ["decoder_label", "default_qc", "firing_rate", "y", "snr", "amplitude_median", "isi_violation_ratio"]
+displayed_unit_properties = [
+    "decoder_label",
+    "default_qc",
+    "firing_rate",
+    "y",
+    "snr",
+    "amplitude_median",
+    "isi_violation_ratio",
+]
 default_curation_dict = {
     "format_version": "2",
     "label_definitions": {
-        "quality":{
+        "quality": {
             "label_options": ["good", "MUA", "noise"],
             "exclusive": True,
-        }, 
+        },
     },
     "manual_labels": [],
     "removed": [],
@@ -76,9 +84,11 @@ class EphysGuiView(param.Parameterized):
                 self._create_main_window(),
                 sizing_mode="stretch_both",
             )
+
             def delayed_init():
                 self._initialize()
                 return False
+
             self._init_cb = pn.state.add_periodic_callback(delayed_init, period=1500, count=1)
         else:
             self.layout = pn.Column(
@@ -92,8 +102,10 @@ class EphysGuiView(param.Parameterized):
             return
         doc = pn.state.curdoc
         if doc is not None and hasattr(doc, "on_session_destroyed"):
+
             def _on_destroy(session_context, view=self):
                 view.cleanup()
+
             doc.on_session_destroyed(_on_destroy)
             self._cleanup_registered = True
             print(f"[GUI] Cleanup registered on doc {id(doc)}")
@@ -106,11 +118,13 @@ class EphysGuiView(param.Parameterized):
         self.log_output.value = ""
 
         initial_mem = psutil.virtual_memory()
-        total_ram = initial_mem.total / (1024 ** 3)
-        current_ram_usage = initial_mem.used / (1024 ** 3)
-        available_ram = initial_mem.available / (1024 ** 3)
+        total_ram = initial_mem.total / (1024**3)
+        current_ram_usage = initial_mem.used / (1024**3)
+        available_ram = initial_mem.available / (1024**3)
         print(f"\nRAM Usage before initialization:")
-        print(f"\tUsed: {current_ram_usage:.2f}/{total_ram:.2f} GB\n\tAvailable: {available_ram:.2f}/{total_ram:.2f} GB\n")
+        print(
+            f"\tUsed: {current_ram_usage:.2f}/{total_ram:.2f} GB\n\tAvailable: {available_ram:.2f}/{total_ram:.2f} GB\n"
+        )
         with local_log_context(self.log_output):
             error = None
             if self.analyzer_path != "":
@@ -139,10 +153,12 @@ class EphysGuiView(param.Parameterized):
                 self.layout[0] = pn.pane.Markdown(f"⚠️ Error during initialization: {error}", sizing_mode="stretch_both")
             else:
                 final_mem = psutil.virtual_memory()
-                final_ram_usage = final_mem.used / (1024 ** 3)
-                final_ram_available = final_mem.available / (1024 ** 3)
+                final_ram_usage = final_mem.used / (1024**3)
+                final_ram_available = final_mem.available / (1024**3)
                 print(f"\nRAM Usage after initialization:")
-                print(f"\tUsed: {final_ram_usage:.2f}/{total_ram:.2f} GB\n\tAvailable: {final_ram_available:.2f}/{total_ram:.2f} GB\n")
+                print(
+                    f"\tUsed: {final_ram_usage:.2f}/{total_ram:.2f} GB\n\tAvailable: {final_ram_available:.2f}/{total_ram:.2f} GB\n"
+                )
 
     def _initialize_analyzer(self):
         if not self.analyzer_path.endswith((".zarr", ".zarr/")):
@@ -194,11 +210,11 @@ class EphysGuiView(param.Parameterized):
                 curation_dict=curation_dict,
                 mode="web",
                 start_app=False,
-                # for testing
-                skip_extensions=["waveforms", "principal_components"],
                 panel_window_servable=False,
                 verbose=True,
-                layout=aind_layout
+                layout=aind_layout,
+                # UNCOMMENT THIS TO SPEED UP TESTING
+                # skip_extensions=["waveforms", "principal_components"],
             )
             self.win = win
             return win.main_layout
@@ -209,8 +225,8 @@ class EphysGuiView(param.Parameterized):
         """Release resources when the session is closed."""
         print("Cleaning up Ephys GUI resources...")
         initial_mem = psutil.virtual_memory()
-        total_ram = initial_mem.total / (1024 ** 3)
-        current_ram_usage = initial_mem.used / (1024 ** 3)
+        total_ram = initial_mem.total / (1024**3)
+        current_ram_usage = initial_mem.used / (1024**3)
         print(f"\nRAM Usage before cleanup: {current_ram_usage:.2f} / {total_ram:.2f} GB\n")
 
         # 1) Release GUI controller references
@@ -251,12 +267,12 @@ class EphysGuiView(param.Parameterized):
         #     print(f"malloc_trim failed: {e}")
 
         final_mem = psutil.virtual_memory()
-        current_ram_usage = final_mem.used / (1024 ** 3)
+        current_ram_usage = final_mem.used / (1024**3)
         print(f"\nRAM Usage after cleanup: {current_ram_usage:.2f} / {total_ram:.2f} GB\n")
-
 
         # Debug: compare RSS vs OS-reported used
         import os
+
         process = psutil.Process(os.getpid())
         rss = process.memory_info().rss / 1024**2
         print(f"\nProcess RSS: {rss:.1f} MB")

--- a/src/aind_ephys_portal/panel/ephys_portal.py
+++ b/src/aind_ephys_portal/panel/ephys_portal.py
@@ -79,7 +79,6 @@ class EphysPortal:
     def update_results(self, event):
         """Update the results panel with the current search results."""
         print("Updating search results...")
-        print(event)
         if event is None:
             df = self.search_options.df
         elif event.name == "clicks":
@@ -183,10 +182,12 @@ class EphysPortal:
             pn.pane.Markdown("## Postprocessed Streams", styles={"text-align": "left"}),
             self.streams_panel,
             min_width=900,
+            max_width=1400,
+            sizing_mode="stretch_width",
             styles=OUTER_STYLE,
             align="center",
         )
-        display = pn.Row(pn.HSpacer(), col, pn.HSpacer())
+        display = pn.Row(pn.HSpacer(max_width=50), col, pn.HSpacer(max_width=50))
 
         return display
 
@@ -209,8 +210,8 @@ class SearchOptions(param.Parameterized):
         data = []
         try:
             # Get initial data from database
-            self.all_records = get_all_ecephys_derived()
-            print(f"Loaded {len(self.all_records)} records.")
+            self.all_records = get_all_ecephys_derived(additional_includes_in_name="sorted")
+            print(f"Loaded {len(self.all_records)} 'sorted' records.")
             # Process records into a list of dictionaries
             for record in self.all_records:
                 r = {
@@ -258,8 +259,10 @@ class SearchOptions(param.Parameterized):
 
         # Search for records matching the text filter
         try:
-            # Make sure we're returning a DataFrame, not a Series
+            # Search first in the 'name' column. If no matches, we check for the dataset ID
             mask = self.df["name"].str.contains(text_filter, case=False)
+            if not mask.any():
+                mask = self.df["id"].str.contains(text_filter, case=False)
             df_filtered = self.df[mask]
             return df_filtered
         except Exception as e:

--- a/src/aind_ephys_portal/panel/ephys_portal.py
+++ b/src/aind_ephys_portal/panel/ephys_portal.py
@@ -69,9 +69,7 @@ class EphysPortal:
         # Update the streams panel when a row is selected
         self.results_panel.on_click(self.update_streams)
 
-        self.refresh_button = pn.widgets.Button(
-            name="Refresh Datasets", button_type="primary", height=30, width=150
-        )
+        self.refresh_button = pn.widgets.Button(name="Refresh Datasets", button_type="primary", height=30, width=150)
         self.refresh_button.on_click(self.update_results)
         # Initialize with current results
         self.update_results(None)
@@ -121,7 +119,7 @@ class EphysPortal:
                     raw_asset_prefix = self.get_raw_asset_location(raw_asset["location"])
                     print(f"Raw asset prefix: {raw_asset_prefix}")
                     if raw_asset_prefix is None:
-                        recording_path=""
+                        recording_path = ""
                     else:
                         recording_path = f"{raw_asset_prefix}/{raw_stream_name}.zarr"
                     analyzer_path = f"{analyzer_base_location}/postprocessed/{stream_name}"
@@ -148,7 +146,7 @@ class EphysPortal:
         self.streams_panel.value = streams_df
 
     def get_raw_asset_location(self, asset_location):
-        asset_without_s3 = asset_location[asset_location.find("s3://") + 5:]
+        asset_without_s3 = asset_location[asset_location.find("s3://") + 5 :]
         asset_split = asset_without_s3.split("/")
         bucket_name = asset_split[0]
         session_name = "/".join(asset_split[1:])
@@ -182,12 +180,12 @@ class EphysPortal:
             pn.pane.Markdown("## Postprocessed Streams", styles={"text-align": "left"}),
             self.streams_panel,
             min_width=900,
-            max_width=1400,
+            max_width=1200,
             sizing_mode="stretch_width",
             styles=OUTER_STYLE,
             align="center",
         )
-        display = pn.Row(pn.HSpacer(max_width=50), col, pn.HSpacer(max_width=50))
+        display = pn.Row(pn.HSpacer(max_width=200), col, pn.HSpacer(max_width=200))
 
         return display
 

--- a/src/aind_ephys_portal/panel/ephys_portal.py
+++ b/src/aind_ephys_portal/panel/ephys_portal.py
@@ -8,6 +8,7 @@ import boto3
 
 from aind_ephys_portal.docdb.database import get_raw_asset_by_name, get_all_ecephys_derived
 from aind_ephys_portal.panel.utils import format_link, OUTER_STYLE, EPHYSGUI_LINK_PREFIX
+from aind_ephys_portal.panel.logging import setup_logging
 
 s3_client = boto3.client("s3")
 
@@ -25,6 +26,7 @@ class EphysPortal:
 
     def __init__(self):
         """Initialize the SIGUI Portal application."""
+        setup_logging()  # Ensure logging is set up for this panel
         self.search_options = SearchOptions()
         # Get the search input widget
         self.search_bar = pn.widgets.TextInput(

--- a/src/aind_ephys_portal/panel/logging.py
+++ b/src/aind_ephys_portal/panel/logging.py
@@ -1,72 +1,80 @@
 import io
 import sys
-import panel as pn
 import contextvars
+from pathlib import Path
+
+import panel as pn
 
 pn.extension()
 
-_buffers = {}
+LOG_DIR = Path("/tmp/aind_ephys_logs")
 _log_setup = False
 _local_sink = contextvars.ContextVar("local_sink", default=None)
 
 
-def _get_session_id():
-    session_id = getattr(pn.state, "session_id", None)
-    if session_id:
-        return session_id
-    doc = getattr(pn.state, "curdoc", None)
-    if doc and getattr(doc, "session_context", None):
-        return id(doc.session_context)
-    return "no-session"
+def _log_path_for_session(route, session_id):
+    return LOG_DIR / route / str(session_id)
 
 
-def _key(pathname=None, session_id=None):
-    if pathname is None:
-        location = getattr(pn.state, "location", None)
-        pathname = location.pathname if location else "/"
-    if session_id is None:
-        session_id = _get_session_id()
-    return (pathname, session_id)
+def _get_current_log_path():
+    """Get the log path for the current request from curdoc."""
+    try:
+        doc = pn.state.curdoc
+        if doc is not None:
+            route = getattr(doc, "_log_route", None)
+            session_id = getattr(doc, "_log_session_id", None)
+            if route and session_id:
+                return _log_path_for_session(route, session_id)
+    except Exception:
+        pass
+    return None
 
 
-def get_buffer(pathname=None, session_id=None):
-    key = _key(pathname, session_id)
-    if key not in _buffers:
-        _buffers[key] = pn.widgets.TextAreaInput(value="", sizing_mode="stretch_both")
-    return _buffers[key]
+def add_session(route, session_id):
+    """Create a log file for this session."""
+    path = _log_path_for_session(route, session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text("")
+    return path
 
 
-def list_buffers(skip_routes=None):
+def remove_session(route, session_id):
+    """Remove the log file for this session."""
+    path = _log_path_for_session(route, session_id)
+    if path.exists():
+        path.unlink()
+    # Clean up empty route dir
+    try:
+        if path.parent.exists() and not any(path.parent.iterdir()):
+            path.parent.rmdir()
+    except Exception:
+        pass
+
+
+def set_session_log_path(route, session_id):
+    """No-op kept for compatibility."""
+    pass
+
+
+def list_sessions(skip_routes=None):
+    """Return dict of {(route, session_id): Path} for all active log files."""
     if skip_routes is None:
         skip_routes = []
-    buffer_list = list(_buffers.keys())
-    buffers = {}
-    for key in buffer_list:
-        route, session_id = key
-        if any(s in route for s in skip_routes):
+    sessions = {}
+    if not LOG_DIR.exists():
+        return sessions
+    for route_dir in LOG_DIR.iterdir():
+        if not route_dir.is_dir():
             continue
-        if isinstance(session_id, str) and session_id == "no-session":
+        route = route_dir.name
+        if route in skip_routes:
             continue
-        buffers[key] = _buffers[key]
-    return buffers
-
-
-def remove_buffer(key):
-    return _buffers.pop(key, None)
-
-
-def add_session(session_id, pathname=None):
-    key = _key(pathname=pathname, session_id=session_id)
-    if key not in _buffers:
-        _buffers[key] = pn.widgets.TextAreaInput(value="", sizing_mode="stretch_both")
-    return _buffers[key]
-
-
-def clear_session(session_id):
-    keys = [k for k in _buffers.keys() if k[1] == session_id]
-    for k in keys:
-        _buffers.pop(k, None)
-    return len(keys)
+        for log_file in route_dir.iterdir():
+            if log_file.is_file():
+                session_id = log_file.name
+                sessions[(route, session_id)] = log_file
+    return sessions
 
 
 class MultiSessionTee(io.TextIOBase):
@@ -76,14 +84,22 @@ class MultiSessionTee(io.TextIOBase):
     def write(self, data):
         self.original.write(data)
 
-        # Global per-session buffer
-        buf = get_buffer()
-        buf.value = buf.value + data
+        # Write to session log file (from curdoc)
+        path = _get_current_log_path()
+        if path is not None and path.exists():
+            try:
+                with open(path, "a") as f:
+                    f.write(data)
+            except Exception:
+                pass
 
         # Optional local sink (e.g., GUI init panel)
         sink = _local_sink.get()
         if sink is not None:
-            sink.value = sink.value + data
+            try:
+                sink.value = sink.value + data
+            except Exception:
+                pass
 
         return len(data)
 
@@ -109,6 +125,8 @@ def setup_logging():
     global _log_setup
     if _log_setup:
         return
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
     sys.stdout = MultiSessionTee(sys.stdout)
     sys.stderr = MultiSessionTee(sys.stderr)
     _log_setup = True
+

--- a/src/aind_ephys_portal/panel/logging.py
+++ b/src/aind_ephys_portal/panel/logging.py
@@ -1,0 +1,114 @@
+import io
+import sys
+import panel as pn
+import contextvars
+
+pn.extension()
+
+_buffers = {}
+_log_setup = False
+_local_sink = contextvars.ContextVar("local_sink", default=None)
+
+
+def _get_session_id():
+    session_id = getattr(pn.state, "session_id", None)
+    if session_id:
+        return session_id
+    doc = getattr(pn.state, "curdoc", None)
+    if doc and getattr(doc, "session_context", None):
+        return id(doc.session_context)
+    return "no-session"
+
+
+def _key(pathname=None, session_id=None):
+    if pathname is None:
+        location = getattr(pn.state, "location", None)
+        pathname = location.pathname if location else "/"
+    if session_id is None:
+        session_id = _get_session_id()
+    return (pathname, session_id)
+
+
+def get_buffer(pathname=None, session_id=None):
+    key = _key(pathname, session_id)
+    if key not in _buffers:
+        _buffers[key] = pn.widgets.TextAreaInput(value="", sizing_mode="stretch_both")
+    return _buffers[key]
+
+
+def list_buffers(skip_routes=None):
+    if skip_routes is None:
+        skip_routes = []
+    buffer_list = list(_buffers.keys())
+    buffers = {}
+    for key in buffer_list:
+        route, session_id = key
+        if any(s in route for s in skip_routes):
+            continue
+        if isinstance(session_id, str) and session_id == "no-session":
+            continue
+        buffers[key] = _buffers[key]
+    return buffers
+
+
+def remove_buffer(key):
+    return _buffers.pop(key, None)
+
+
+def add_session(session_id, pathname=None):
+    key = _key(pathname=pathname, session_id=session_id)
+    if key not in _buffers:
+        _buffers[key] = pn.widgets.TextAreaInput(value="", sizing_mode="stretch_both")
+    return _buffers[key]
+
+
+def clear_session(session_id):
+    keys = [k for k in _buffers.keys() if k[1] == session_id]
+    for k in keys:
+        _buffers.pop(k, None)
+    return len(keys)
+
+
+class MultiSessionTee(io.TextIOBase):
+    def __init__(self, original):
+        self.original = original
+
+    def write(self, data):
+        self.original.write(data)
+
+        # Global per-session buffer
+        buf = get_buffer()
+        buf.value = buf.value + data
+
+        # Optional local sink (e.g., GUI init panel)
+        sink = _local_sink.get()
+        if sink is not None:
+            sink.value = sink.value + data
+
+        return len(data)
+
+    def flush(self):
+        self.original.flush()
+
+
+class local_log_context:
+    def __init__(self, widget):
+        self.widget = widget
+        self._token = None
+
+    def __enter__(self):
+        self._token = _local_sink.set(self.widget)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._token is not None:
+            _local_sink.reset(self._token)
+
+
+def setup_logging():
+    global _log_setup
+    if _log_setup:
+        return
+    sys.stdout = MultiSessionTee(sys.stdout)
+    sys.stderr = MultiSessionTee(sys.stderr)
+    _log_setup = True

--- a/src/aind_ephys_portal/panel/logging.py
+++ b/src/aind_ephys_portal/panel/logging.py
@@ -129,4 +129,3 @@ def setup_logging():
     sys.stdout = MultiSessionTee(sys.stdout)
     sys.stderr = MultiSessionTee(sys.stderr)
     _log_setup = True
-

--- a/src/aind_ephys_portal/panel/utils.py
+++ b/src/aind_ephys_portal/panel/utils.py
@@ -55,31 +55,3 @@ def format_css_background():
     }}
     """
     pn.config.raw_css.append(BACKGROUND_CSS)  # type: ignore
-
-
-class Tee(io.StringIO):
-    def __init__(self, log_output):
-        super().__init__()
-        self.log_output = log_output
-        self._orig_out = None
-        self._orig_err = None
-
-    def __enter__(self):
-        self._orig_out = sys.stdout
-        self._orig_err = sys.stderr
-        sys.stdout = self
-        sys.stderr = self
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        sys.stdout = self._orig_out
-        sys.stderr = self._orig_err
-
-    def write(self, message):
-        if self._orig_out:
-            self._orig_out.write(message)
-        self.log_output.value += message
-
-    def flush(self):
-        if self._orig_out:
-            self._orig_out.flush()

--- a/src/aind_ephys_portal/panel/utils.py
+++ b/src/aind_ephys_portal/panel/utils.py
@@ -1,5 +1,7 @@
-import panel as pn
 import io
+import sys
+
+import panel as pn
 
 EPHYSGUI_LINK_PREFIX = "/ephys_gui_app?analyzer_path={}&recording_path={}"
 
@@ -56,14 +58,28 @@ def format_css_background():
 
 
 class Tee(io.StringIO):
-    def __init__(self, original_stdout, log_output):
+    def __init__(self, log_output):
         super().__init__()
-        self.original_stdout = original_stdout
         self.log_output = log_output
+        self._orig_out = None
+        self._orig_err = None
+
+    def __enter__(self):
+        self._orig_out = sys.stdout
+        self._orig_err = sys.stderr
+        sys.stdout = self
+        sys.stderr = self
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        sys.stdout = self._orig_out
+        sys.stderr = self._orig_err
 
     def write(self, message):
-        self.original_stdout.write(message)  # Print to console
-        self.log_output.value += message  # Append to log output
+        if self._orig_out:
+            self._orig_out.write(message)
+        self.log_output.value += message
 
     def flush(self):
-        self.original_stdout.flush()
+        if self._orig_out:
+            self._orig_out.flush()

--- a/src/aind_ephys_portal/setup.py
+++ b/src/aind_ephys_portal/setup.py
@@ -1,23 +1,48 @@
 import panel as pn
-from aind_ephys_portal.panel.logging import add_session, clear_session, setup_logging
+
+from aind_ephys_portal.panel.logging import add_session, remove_session, setup_logging
 
 setup_logging()
 
-active_sessions = set()
-
 
 def on_session_created(session_context):
-    session_id = id(session_context)
-    active_sessions.add(session_id)
+    request = session_context.request
+
+    # Extract route from the request URL
+    route = "unknown"
+    if hasattr(request, "uri"):
+        parts = request.uri.strip("/").split("?")[0].split("/")
+        route = parts[0] if parts and parts[0] else "unknown"
+    elif hasattr(request, "path"):
+        parts = request.path.strip("/").split("?")[0].split("/")
+        route = parts[0] if parts and parts[0] else "unknown"
+
+    # Skip warm-up / internal sessions
+    if route in ("unknown", "", "ws"):
+        return
+
+    session_id = str(id(session_context))
+
+    # Store on document so apps and destroy callback can find it
+    doc = session_context._document
+    doc._log_route = route
+    doc._log_session_id = session_id
+
+    add_session(route=route, session_id=session_id)
+    print(f"[setup] Session created: {route}/{session_id}")
+
 
 def on_session_destroyed(session_context):
-    session_id = id(session_context)
-    active_sessions.discard(session_id)
-    clear_session(session_id)
+    doc = session_context._document
+    route = getattr(doc, "_log_route", None)
+    session_id = getattr(doc, "_log_session_id", None)
+
+    if route is None or session_id is None:
+        return
+
+    remove_session(route=route, session_id=session_id)
+    print(f"[setup] Session destroyed: {route}/{session_id}")
 
 
 pn.state.on_session_created(on_session_created)
 pn.state.on_session_destroyed(on_session_destroyed)
-
-# Expose the set globally so your main app can read it
-pn.state.active_sessions = active_sessions

--- a/src/aind_ephys_portal/setup.py
+++ b/src/aind_ephys_portal/setup.py
@@ -1,4 +1,7 @@
 import panel as pn
+from aind_ephys_portal.panel.logging import add_session, clear_session, setup_logging
+
+setup_logging()
 
 active_sessions = set()
 
@@ -6,13 +9,11 @@ active_sessions = set()
 def on_session_created(session_context):
     session_id = id(session_context)
     active_sessions.add(session_id)
-    print(f"[+] Session created: {session_id} | Active sessions: {len(active_sessions)}")
-
 
 def on_session_destroyed(session_context):
     session_id = id(session_context)
     active_sessions.discard(session_id)
-    print(f"[-] Session closed: {session_id} | Active sessions: {len(active_sessions)}")
+    clear_session(session_id)
 
 
 pn.state.on_session_created(on_session_created)


### PR DESCRIPTION
This PR restructures the apps to improve usability and monitoring. 
Currently, there are two apps served by panel:
- `ephys_portal_app`: connects to DocDB and allows users to search for datasets and launch the GUI on postprocessed analyzers
- `ephys_gui_app`: renders the GUI AND includes a launcher, log, and monitor tab

With this PR the `ephys_portal_app` is unchanged, but the `ephys_gui_app` is only launched on existing analyzer paths embedded in the URL (so links can be pre-generated as before).
These two new apps are added:

### `ephys_launcher_app`

App specifically to generate `ephys_gui_app` links by specifying analyzer/recording paths and optionally a fast mode (which skips loading waveforms and PCs- for testing)

<img width="2487" height="347" alt="image" src="https://github.com/user-attachments/assets/1d3155f7-fc50-46f6-87a6-8e56855f0a14" />

### `ephys_monitor_app`

App designed for monitoring the server status (CPU/RAM), active sessions, and logs.

Since the app is run on several parallel processes for performance, logs for each session are internally saved to a file (created on session start) and destroyed at when the session is destroyed.

<img width="2486" height="815" alt="image" src="https://github.com/user-attachments/assets/fb0472da-2e11-4625-8048-22960819496b" />

In addition, I added a `cleanup` function for the `ephys_gui_app`, to delete and garbage collect objects as sessions are deleted.
