### PR TITLE
Expose `identifier` and update strategy for bi-directional communication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN git clone https://github.com/SpikeInterface/spikeinterface.git && \
 # Install spikeinterface-gui from source
 RUN git clone https://github.com/alejoe91/spikeinterface-gui.git && \
     cd spikeinterface-gui && \
-    git checkout b8d461ce5e5178880a32fd25cb5c87b94dab86e1 && \
+    git checkout edf817027136ce4b4b8bf20ce5125f7f4be336e5 && \
     pip install . && cd ..
 
 

--- a/launch.sh
+++ b/launch.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PORT=${1:-5006}
+
 # Clean up old logs
 rm -rf /tmp/aind_ephys_logs
 
@@ -12,4 +14,5 @@ panel serve \
     --static-dirs images=src/aind_ephys_portal/images \
     --check-unused-sessions 2000 \
     --unused-session-lifetime 5000 \
+    --port $PORT \
     --num-threads 8

--- a/src/aind_ephys_portal/ephys_gui_app.py
+++ b/src/aind_ephys_portal/ephys_gui_app.py
@@ -12,6 +12,14 @@ import spikeinterface_gui.utils_panel  # noqa: F401
 
 from aind_ephys_portal.panel.ephys_gui import EphysGuiView
 
+def _get_arg(name: str, default: str = "") -> str:
+    """Read a query-parameter from the raw HTTP request."""
+    val = pn.state.session_args.get(name, [default.encode()])
+    if isinstance(val, list):
+        val = val[0]
+    if isinstance(val, bytes):
+        val = val.decode()
+    return val
     
 
 # State sync
@@ -30,13 +38,16 @@ class Settings(param.Parameterized):
 settings = Settings()
 pn.state.location.sync(settings, {"analyzer_path": "analyzer_path", "recording_path": "recording_path", "identifier": "identifier", "fast_mode": "fast_mode"})
 
-# Manually decode stream_name after syncing
-settings.analyzer_path = urllib.parse.unquote(settings.analyzer_path)
-settings.recording_path = urllib.parse.unquote(settings.recording_path)
 
-print(settings)
+print("session_args:", {k: v for k, v in pn.state.session_args.items()})
 
-ephys_gui = EphysGuiView(analyzer_path=settings.analyzer_path, recording_path=settings.recording_path, identifier=settings.identifier, fast_mode=settings.fast_mode)
+
+analyzer_path = urllib.parse.unquote(_get_arg("analyzer_path"))
+recording_path = urllib.parse.unquote(_get_arg("recording_path"))
+identifier = _get_arg("identifier")
+fast_mode = _get_arg("fast_mode", "false").lower() in ("true", "1", "yes")
+
+ephys_gui = EphysGuiView(analyzer_path=analyzer_path, recording_path=recording_path, identifier=identifier, fast_mode=fast_mode)
 
 ephys_gui.panel().servable(title="AIND Ephys GUI")
 

--- a/src/aind_ephys_portal/ephys_gui_app.py
+++ b/src/aind_ephys_portal/ephys_gui_app.py
@@ -12,6 +12,7 @@ import spikeinterface_gui.utils_panel  # noqa: F401
 
 from aind_ephys_portal.panel.ephys_gui import EphysGuiView
 
+    
 
 # State sync
 class Settings(param.Parameterized):
@@ -19,6 +20,7 @@ class Settings(param.Parameterized):
 
     analyzer_path = param.String(default="")
     recording_path = param.String(default="")
+    identifier = param.String(default="")
     fast_mode = param.Boolean(
         default=False,
         doc="Whether to enable fast mode (skips waveforms and principal components)"
@@ -26,13 +28,15 @@ class Settings(param.Parameterized):
 
 
 settings = Settings()
-pn.state.location.sync(settings, {"analyzer_path": "analyzer_path", "recording_path": "recording_path", "fast_mode": "fast_mode"})
+pn.state.location.sync(settings, {"analyzer_path": "analyzer_path", "recording_path": "recording_path", "identifier": "identifier", "fast_mode": "fast_mode"})
 
 # Manually decode stream_name after syncing
 settings.analyzer_path = urllib.parse.unquote(settings.analyzer_path)
 settings.recording_path = urllib.parse.unquote(settings.recording_path)
 
-ephys_gui = EphysGuiView(analyzer_path=settings.analyzer_path, recording_path=settings.recording_path, fast_mode=settings.fast_mode)
+print(settings)
+
+ephys_gui = EphysGuiView(analyzer_path=settings.analyzer_path, recording_path=settings.recording_path, identifier=settings.identifier, fast_mode=settings.fast_mode)
 
 ephys_gui.panel().servable(title="AIND Ephys GUI")
 

--- a/src/aind_ephys_portal/ephys_gui_app.py
+++ b/src/aind_ephys_portal/ephys_gui_app.py
@@ -33,21 +33,27 @@ class Settings(param.Parameterized):
         default=False,
         doc="Whether to enable fast mode (skips waveforms and principal components)"
     )
+    preload_curation = param.Boolean(
+        default=False,
+        doc="Whether to preload existing curation from disk (if available)"
+    )
 
 
 settings = Settings()
-pn.state.location.sync(settings, {"analyzer_path": "analyzer_path", "recording_path": "recording_path", "identifier": "identifier", "fast_mode": "fast_mode"})
+pn.state.location.sync(settings, {"analyzer_path": "analyzer_path", "recording_path": "recording_path", "identifier": "identifier", "fast_mode": "fast_mode", "preload_curation": "preload_curation"})
 
-
-print("session_args:", {k: v for k, v in pn.state.session_args.items()})
 
 
 analyzer_path = urllib.parse.unquote(_get_arg("analyzer_path"))
 recording_path = urllib.parse.unquote(_get_arg("recording_path"))
-identifier = _get_arg("identifier")
+identifier = urllib.parse.unquote(_get_arg("identifier"))
 fast_mode = _get_arg("fast_mode", "false").lower() in ("true", "1", "yes")
+preload_curation = _get_arg("preload_curation", "false").lower() in ("true", "1", "yes")
 
-ephys_gui = EphysGuiView(analyzer_path=analyzer_path, recording_path=recording_path, identifier=identifier, fast_mode=fast_mode)
+print(f"Parsed arguments:")
+print(f"\tanalyzer_path={analyzer_path}\n\trecording_path={recording_path}\n\tidentifier={identifier}\n\tfast_mode={fast_mode}\n\tpreload_curation={preload_curation}")
+
+ephys_gui = EphysGuiView(analyzer_path=analyzer_path, recording_path=recording_path, identifier=identifier, fast_mode=fast_mode, preload_curation=preload_curation)
 
 ephys_gui.panel().servable(title="AIND Ephys GUI")
 

--- a/src/aind_ephys_portal/ephys_launcher_app.py
+++ b/src/aind_ephys_portal/ephys_launcher_app.py
@@ -41,6 +41,13 @@ class EphysLauncher:
             sizing_mode="stretch_width",
         )
 
+        self.preload_curation = pn.widgets.Checkbox(
+            name="Preload Curation",
+            value=True,
+            height=30,
+            sizing_mode="stretch_width",
+        )
+
         self.link_pane = pn.pane.HTML("No link generated yet.", sizing_mode="stretch_width")
         self.url_output = pn.widgets.TextInput(
             name="GUI URL",
@@ -55,7 +62,7 @@ class EphysLauncher:
             pn.pane.Markdown("## AIND Ephys Launcher"),
             self.analyzer_input,
             self.recording_input,
-            pn.Row(self.generate_button, self.fast_mode_checkbox, sizing_mode="stretch_width"),
+            pn.Row(self.generate_button, self.fast_mode_checkbox, self.preload_curation, sizing_mode="stretch_width"),
             self.link_pane,
             self.url_output,
             sizing_mode="stretch_width",
@@ -72,6 +79,8 @@ class EphysLauncher:
         path = EPHYSGUI_LINK_PREFIX.format(analyzer_path_q, recording_path_q)
         if self.fast_mode_checkbox.value:
             path += "&fast_mode=true"
+        if self.preload_curation.value:
+            path += "&preload_curation=true"
 
         location = pn.state.location
         if location is not None:

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -1,4 +1,5 @@
 import ctypes
+import json
 import psutil
 import param
 import time
@@ -84,7 +85,6 @@ class EphysGuiView(param.Parameterized):
             identifier = None
         self.identifier = identifier
         self.fast_mode = fast_mode
-        print("Fast mode:", self.fast_mode)
         self.analyzer = None
         self._cleanup_registered = False
         self._init_cb = None
@@ -126,32 +126,30 @@ class EphysGuiView(param.Parameterized):
         submit_trigger.jscallback(
             value="""
             // Extract just the JSON data (remove timestamp suffix)
-            const fullValue = cb_obj.value;
-            const lastUnderscore = fullValue.lastIndexOf('_');
-            const dataStr = lastUnderscore > 0 ? fullValue.substring(0, lastUnderscore) : fullValue;
+            const dataStr = cb_obj.value;
 
-            if (dataStr && dataStr.length > 0) {
-                try {
+            if (dataStr && dataStr.length > 0) {{
+                try {{
                     const data = JSON.parse(dataStr);
                     console.log('Sending data to parent:', data);
-                    parent.postMessage({
+                    parent.postMessage({{
                             type: 'panel-data',
-                            identifier: '%s',
+                            identifier: '{identifier}',
                             data: data
-                        },
+                        }},
                     '*');
                     console.log('Data sent successfully to parent window');
-                } catch (error) {
+                }} catch (error) {{
                     console.error('Error sending data to parent:', error);
-                }
-            }
-            """.format(self.identifier)
+                }}
+            }}
+            """.format(identifier=self.identifier)
         )
         return submit_trigger
 
 
     def _curation_callback(self, curation_data):
-        self.submit_trigger.value = curation_data + f"_{int(time.time() * 1000)}"
+        self.submit_trigger.value = json.dumps(curation_data)
 
     def _set_curation_data_from_message(self, event):
         """
@@ -164,12 +162,19 @@ class EphysGuiView(param.Parameterized):
         }
         """
         msg = event.data
+        print(f"Received message: {msg}")
         payload = (msg or {}).get("payload", {})
-        curation_data = payload.get("data", None)
         identifier = payload.get("identifier", None)
         if identifier != self.identifier:
             print(f"Received message for identifier {identifier}, but current identifier is {self.identifier}. Ignoring.")
             return
+
+        data_type = payload.get("type", None)
+        if data_type != "curation-data":
+            print(f"Received message with type {data_type}, but expected 'curation-data'. Ignoring.")
+            return
+
+        curation_data = payload.get("data", None)
 
         # Optional: validate basic structure
         if not isinstance(curation_data, dict):

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -73,7 +73,7 @@ def _malloc_trim():
 
 class EphysGuiView(param.Parameterized):
 
-    def __init__(self, analyzer_path, recording_path, identifier=None, fast_mode=False, **params):
+    def __init__(self, analyzer_path, recording_path, identifier=None, fast_mode=False, preload_curation=False, **params):
         """Construct the QCPanel object"""
         super().__init__(**params)
 
@@ -85,6 +85,7 @@ class EphysGuiView(param.Parameterized):
             identifier = None
         self.identifier = identifier
         self.fast_mode = fast_mode
+        self.preload_curation = preload_curation
         self.analyzer = None
         self._cleanup_registered = False
         self._init_cb = None
@@ -133,7 +134,7 @@ class EphysGuiView(param.Parameterized):
                     const data = JSON.parse(dataStr);
                     console.log('Sending data to parent:', data);
                     parent.postMessage({{
-                            type: 'panel-data',
+                            type: 'curation-data',
                             identifier: '{identifier}',
                             data: data
                         }},
@@ -292,19 +293,22 @@ class EphysGuiView(param.Parameterized):
     def _create_main_window(self):
         if self.analyzer is not None:
             # prepare the curation data using decoder labels
-            curation_dict = deepcopy(default_curation_dict)
-            curation_dict["unit_ids"] = self.analyzer.unit_ids
-            if "decoder_label" in self.analyzer.sorting.get_property_keys():
-                decoder_labels = self.analyzer.get_sorting_property("decoder_label")
-                noise_units = self.analyzer.unit_ids[decoder_labels == "noise"]
-                curation_dict["removed"] = list(noise_units)
-                for unit_id in noise_units:
-                    curation_dict["manual_labels"].append({"unit_id": unit_id, "quality": ["noise"]})
+            if self.preload_curation:
+                curation_dict = deepcopy(default_curation_dict)
+                curation_dict["unit_ids"] = self.analyzer.unit_ids
+                if "decoder_label" in self.analyzer.sorting.get_property_keys():
+                    decoder_labels = self.analyzer.get_sorting_property("decoder_label")
+                    noise_units = self.analyzer.unit_ids[decoder_labels == "noise"]
+                    curation_dict["removed"] = list(noise_units)
+                    for unit_id in noise_units:
+                        curation_dict["manual_labels"].append({"unit_id": unit_id, "quality": ["noise"]})
 
-            try:
-                validate_curation_dict(curation_dict)
-            except ValueError as e:
-                print(f"Curated dictionary is invalid: {e}")
+                try:
+                    validate_curation_dict(curation_dict)
+                except ValueError as e:
+                    print(f"Curated dictionary is invalid: {e}")
+                    curation_dict = None
+            else:
                 curation_dict = None
 
             if self.fast_mode:

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -112,7 +112,7 @@ class EphysGuiView(param.Parameterized):
                 sizing_mode="stretch_both",
             )
 
-    def add_post_message_listener(self):
+    def create_post_message_listener(self):
         if self.identifier is not None:
             listener = PostMessageListener()
             listener.on_msg(self._set_curation_data_from_message)
@@ -120,8 +120,7 @@ class EphysGuiView(param.Parameterized):
             listener = None
         return listener
 
-    def create_curation_trigger(self):
-        # Create objects to submit and listen
+    def create_submit_trigger(self):
         submit_trigger = pn.widgets.TextInput(value="", visible=False)
         # Add JavaScript callback that triggers when the TextInput value changes
         submit_trigger.jscallback(
@@ -234,9 +233,9 @@ class EphysGuiView(param.Parameterized):
                     if self.identifier is not None:
                         print(f"\nSetting up bi-directional communication with identifier: {self.identifier}")
                         # Add custom curation callback to send data to parent window
-                        self.submit_trigger = self.create_curation_trigger()
+                        self.submit_trigger = self.create_submit_trigger()
                         # Add postMessage listener to receive data from parent window
-                        self.listener = self.add_post_message_listener()
+                        self.listener = self.create_post_message_listener()
 
                     self.win_layout = self._create_main_window()
                     self.layout[0] = self.win_layout

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -17,6 +17,7 @@ from spikeinterface.core.core_tools import extractor_dict_iterator, set_value_in
 from spikeinterface.curation import validate_curation_dict
 
 from aind_ephys_portal.panel.logging import setup_logging, local_log_context
+from aind_ephys_portal.panel.utils import PostMessageListener
 
 
 displayed_unit_properties = [
@@ -71,7 +72,7 @@ def _malloc_trim():
 
 class EphysGuiView(param.Parameterized):
 
-    def __init__(self, analyzer_path, recording_path, fast_mode=False, **params):
+    def __init__(self, analyzer_path, recording_path, identifier=None, fast_mode=False, **params):
         """Construct the QCPanel object"""
         super().__init__(**params)
 
@@ -79,7 +80,11 @@ class EphysGuiView(param.Parameterized):
 
         self.analyzer_path = analyzer_path
         self.recording_path = recording_path
+        if identifier is not None and identifier == "":
+            identifier = None
+        self.identifier = identifier
         self.fast_mode = fast_mode
+        print("Fast mode:", self.fast_mode)
         self.analyzer = None
         self._cleanup_registered = False
         self._init_cb = None
@@ -105,6 +110,72 @@ class EphysGuiView(param.Parameterized):
                 pn.pane.Markdown(help_txt, sizing_mode="stretch_both"),
                 sizing_mode="stretch_both",
             )
+
+    def add_post_message_listener(self):
+        if self.identifier is not None:
+            listener = PostMessageListener()
+            listener.on_msg(self._set_curation_data_from_message)
+        else:
+            listener = None
+        return listener
+
+    def create_curation_trigger(self):
+        # Create objects to submit and listen
+        submit_trigger = pn.widgets.TextInput(value="", visible=False)
+        # Add JavaScript callback that triggers when the TextInput value changes
+        submit_trigger.jscallback(
+            value="""
+            // Extract just the JSON data (remove timestamp suffix)
+            const fullValue = cb_obj.value;
+            const lastUnderscore = fullValue.lastIndexOf('_');
+            const dataStr = lastUnderscore > 0 ? fullValue.substring(0, lastUnderscore) : fullValue;
+
+            if (dataStr && dataStr.length > 0) {
+                try {
+                    const data = JSON.parse(dataStr);
+                    console.log('Sending data to parent:', data);
+                    parent.postMessage({
+                            type: 'panel-data',
+                            identifier: '%s',
+                            data: data
+                        },
+                    '*');
+                    console.log('Data sent successfully to parent window');
+                } catch (error) {
+                    console.error('Error sending data to parent:', error);
+                }
+            }
+            """.format(self.identifier)
+        )
+        return submit_trigger
+
+
+    def _curation_callback(self, curation_data):
+        self.submit_trigger.value = curation_data + f"_{int(time.time() * 1000)}"
+
+    def _set_curation_data_from_message(self, event):
+        """
+        Handler for PostMessageListener.on_msg.
+
+        event.data is whatever the JS side passed to model.send_msg(...).
+        Expected shape:
+        {
+            "payload": {"type": "curation-data", "identifier": "<identifier>", "data": <curation_dict>},
+        }
+        """
+        msg = event.data
+        payload = (msg or {}).get("payload", {})
+        curation_data = payload.get("data", None)
+        identifier = payload.get("identifier", None)
+        if identifier != self.identifier:
+            print(f"Received message for identifier {identifier}, but current identifier is {self.identifier}. Ignoring.")
+            return
+
+        # Optional: validate basic structure
+        if not isinstance(curation_data, dict):
+            print("Invalid curation_data type:", type(curation_data), curation_data)
+            return
+        self.sigui_win.set_external_curation(curation_data)
 
     def _register_cleanup(self):
         """Register cleanup on the current document. Must be called from within the session."""
@@ -153,8 +224,20 @@ class EphysGuiView(param.Parameterized):
                     self._initialize_analyzer()
                     if self.recording_path != "":
                         self._set_processed_recording()
-                    win = self._create_main_window()
-                    self.layout[0] = win
+
+                    if self.identifier is not None:
+                        print(f"\nSetting up bi-directional communication with identifier: {self.identifier}")
+                        # Add custom curation callback to send data to parent window
+                        self.submit_trigger = self.create_curation_trigger()
+                        # Add postMessage listener to receive data from parent window
+                        self.listener = self.add_post_message_listener()
+
+                    self.win_layout = self._create_main_window()
+                    self.layout[0] = self.win_layout
+                    if self.identifier is not None:
+                        self.layout.append(self.submit_trigger)
+                        self.layout.append(self.listener)
+
                     print("\nEphys GUI initialized successfully!")
                     t_stop = time.perf_counter()
                     print(f"Initialization time: {t_stop - t_start:.2f} seconds")
@@ -224,6 +307,8 @@ class EphysGuiView(param.Parameterized):
             else:
                 skip_extensions = None
 
+            curation_callback = self._curation_callback if self.identifier is not None else None
+
             win = run_mainwindow(
                 analyzer=self.analyzer,
                 curation=True,
@@ -235,8 +320,9 @@ class EphysGuiView(param.Parameterized):
                 verbose=True,
                 layout=aind_layout,
                 skip_extensions=skip_extensions,
+                curation_callback=curation_callback,
             )
-            self.win = win
+            self.sigui_win = win
             return win.main_layout
         else:
             return pn.pane.Markdown(help_txt, sizing_mode="stretch_both")
@@ -250,13 +336,17 @@ class EphysGuiView(param.Parameterized):
         print(f"\nRAM Usage before cleanup: {current_ram_usage:.2f} / {total_ram:.2f} GB\n")
 
         # 1) Release GUI controller references
-        if self.win is not None:
-            self.win.controller.analyzer = None
-            del self.win.controller.analyzer
-            self.win.controller = None
-            del self.win.controller
-            self.win = None
-            del self.win
+        if self.sigui_win is not None:
+            self.sigui_win.controller.analyzer = None
+            del self.sigui_win.controller.analyzer
+            self.sigui_win.controller = None
+            del self.sigui_win.controller
+            self.sigui_win = None
+            del self.sigui_win
+
+        if self.win_layout is not None:
+            self.win_layout = None
+            del self.win_layout
 
         # 2) Delete the analyzer reference to release memory-mapped files and other resources
         if self.analyzer is not None:

--- a/src/aind_ephys_portal/panel/utils.py
+++ b/src/aind_ephys_portal/panel/utils.py
@@ -1,7 +1,8 @@
-import io
-import sys
-
 import panel as pn
+
+from panel.param import param
+from panel.custom import ReactComponent
+
 
 EPHYSGUI_LINK_PREFIX = "/ephys_gui_app?analyzer_path={}&recording_path={}"
 
@@ -55,3 +56,42 @@ def format_css_background():
     }}
     """
     pn.config.raw_css.append(BACKGROUND_CSS)  # type: ignore
+
+
+
+class PostMessageListener(ReactComponent):
+    """
+    Listen to window.postMessage events and forward them to Python via on_msg().
+    This avoids ReactiveHTML/Bokeh 'source' linkage issues.
+    """
+    _model_name = "PostMessageListener"
+    _model_module = "post_message_listener"
+    _model_module_version = "0.0.1"
+
+    # If set, only forward messages whose event.data.type matches this value.
+    accept_type = param.String(default="curation-data")
+
+    _esm = """
+    export function render({ model }) {
+      const [accept_type] = model.useState("accept_type");
+
+      function onMessage(event) {
+        const data = event.data;
+
+        // Ignore messages from browser extensions
+        if (data && data.source === "react-devtools-content-script") return;
+
+        if (accept_type && data && data.type !== accept_type) return;
+
+        // Always include a timestamp so repeated sends still look "new"
+        model.send_msg({ payload: data, _ts: Date.now() });
+      }
+
+      React.useEffect(() => {
+        window.addEventListener("message", onMessage);
+        return () => window.removeEventListener("message", onMessage);
+      }, [accept_type]);
+
+      return <></>;
+    }
+    """

--- a/src/aind_ephys_portal/panel/utils.py
+++ b/src/aind_ephys_portal/panel/utils.py
@@ -4,7 +4,7 @@ from panel.param import param
 from panel.custom import ReactComponent
 
 
-EPHYSGUI_LINK_PREFIX = "/ephys_gui_app?analyzer_path={}&recording_path={}"
+EPHYSGUI_LINK_PREFIX = "/ephys_gui_app?analyzer_path={}&recording_path={}&preload_curation=true"
 
 
 AIND_COLORS = colors = {

--- a/tests/test_bidirectional_communication.py
+++ b/tests/test_bidirectional_communication.py
@@ -62,33 +62,46 @@ class ParentPostMessageListener(ReactComponent):
 class IFramePostMessageSender(ReactComponent):
     """
     Invisible component that, whenever *message_json* changes, posts a
-    ``curation-data`` message into the iframe whose id matches *target_iframe_id*.
+    ``curation-data`` message into all iframes (including Shadow DOMs) on the page.
     """
 
     message_json = param.String(default="")
-    target_iframe_id = param.String(default="")
 
     _esm = """
     export function render({ model }) {
       const [messageJson] = model.useState("message_json");
-      const [targetId]    = model.useState("target_iframe_id");
+
+      function findIframes(root) {
+        const results = [];
+        // Direct iframes under this root
+        root.querySelectorAll("iframe").forEach((el) => results.push(el));
+        // Recurse into shadow roots
+        root.querySelectorAll("*").forEach((el) => {
+          if (el.shadowRoot) {
+            findIframes(el.shadowRoot).forEach((f) => results.push(f));
+          }
+        });
+        return results;
+      }
 
       React.useEffect(() => {
         if (!messageJson) return;
 
-        // Strip the timestamp suffix we append to force change detection
         const lastUnderscore = messageJson.lastIndexOf("_");
         const raw = lastUnderscore > 0 ? messageJson.substring(0, lastUnderscore) : messageJson;
         if (!raw) return;
 
         try {
           const parsed = JSON.parse(raw);
-          const iframe = document.getElementById(targetId);
-          if (iframe && iframe.contentWindow) {
-            iframe.contentWindow.postMessage(parsed, "*");
-            console.log(`[parent] Sent to iframe#${targetId}:`, parsed);
-          } else {
-            console.warn(`[parent] iframe#${targetId} not found`);
+          const iframes = findIframes(document);
+          iframes.forEach((iframe) => {
+            if (iframe.contentWindow) {
+              iframe.contentWindow.postMessage(parsed, "*");
+              console.log(`[parent] Sent to iframe#${iframe.id || '(no id)'}:`, parsed);
+            }
+          });
+          if (iframes.length === 0) {
+            console.warn("[parent] No iframes found on the page (including shadow DOMs)");
           }
         } catch (err) {
           console.error("[parent] JSON parse error:", err);
@@ -106,7 +119,7 @@ def iframe_url(identifier: str) -> str:
     return (
         f"http://localhost:{EPHYS_GUI_PORT}/ephys_gui_app"
         f"?analyzer_path={urllib.parse.quote(ANALYZER_PATH)}&"
-        f"recording_path=&identifier={identifier}&fast_mode=true"
+        f"identifier={identifier}&fast_mode=true"
     )
 
 
@@ -120,15 +133,15 @@ iframe_0000 = pn.pane.HTML(
     f'<iframe id="iframe-0000" src="{iframe_url("0000")}" '
     f'style="width:100%;height:100%;border:2px solid #2A7DE1;border-radius:6px;" '
     f'allow="cross-origin-isolated"></iframe>',
-    sizing_mode="stretch_both",
-    min_height=500,
+    height=600,
+    sizing_mode="stretch_width",
 )
 iframe_0001 = pn.pane.HTML(
     f'<iframe id="iframe-0001" src="{iframe_url("0001")}" '
     f'style="width:100%;height:100%;border:2px solid #1D8649;border-radius:6px;" '
     f'allow="cross-origin-isolated"></iframe>',
-    sizing_mode="stretch_both",
-    min_height=500,
+    height=600,
+    sizing_mode="stretch_width",
 )
 
 # Received-messages log
@@ -147,7 +160,8 @@ listener = ParentPostMessageListener()
 
 def _on_receive(msg):
     """Callback fired when a panel-data message arrives from any iframe."""
-    payload = msg.get("payload", {})
+    data = msg.data
+    payload = data.get("payload", {})
     identifier = payload.get("identifier", "???")
     data = payload.get("data", "")
     ts = datetime.datetime.now().strftime("%H:%M:%S")
@@ -168,9 +182,10 @@ target_select = pn.widgets.Select(
 
 send_textarea = pn.widgets.TextAreaInput(
     name="✏️  Curation data to send (JSON)",
-    value='{"manual_labels": [{"unit_id": 0, "quality": ["good"]}]}',
-    sizing_mode="stretch_width",
-    min_height=120,
+    value="",
+    sizing_mode="stretch_both",
+    min_height=200,
+    max_length=500000,
 )
 
 send_button = pn.widgets.Button(name="Send ➤", button_type="primary", width=120)
@@ -184,13 +199,15 @@ def _on_send(event):
     """Build a curation-data postMessage payload and push it into the sender."""
     identifier = target_select.value
     raw = send_textarea.value.strip()
-    if not raw:
-        return
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        received_log.value = f"⚠️  Invalid JSON: {exc}\n" + received_log.value
-        return
+
+    if len(raw) == 0:
+        data = {}
+    else:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            received_log.value = f"⚠️  Invalid JSON: {exc}\n" + received_log.value
+            return
 
     envelope = {
         "type": "curation-data",
@@ -198,7 +215,6 @@ def _on_send(event):
         "data": data,
     }
 
-    sender.target_iframe_id = f"iframe-{identifier}"
     # Append a unique counter so the param change always fires
     _send_counter[0] += 1
     sender.message_json = json.dumps(envelope) + f"_{_send_counter[0]}"
@@ -221,23 +237,22 @@ header = pn.pane.Markdown(
     sizing_mode="stretch_width",
 )
 
-iframes_row = pn.Row(
-    pn.Column("### iframe 0000", iframe_0000, sizing_mode="stretch_both"),
-    pn.Column("### iframe 0001", iframe_0001, sizing_mode="stretch_both"),
+iframes_row = pn.Tabs(
+    ("### iframe 0000", iframe_0000),
+    ("### iframe 0001", iframe_0001),
     sizing_mode="stretch_both",
-    min_height=500,
 )
 
 send_panel = pn.Column(
     pn.Row(target_select, send_button, align="end"),
     send_textarea,
-    sizing_mode="stretch_width",
+    sizing_mode="stretch_both",
 )
 
 comm_row = pn.Row(
     pn.Column("### Send", send_panel, sizing_mode="stretch_both"),
     pn.Column("### Receive", received_log, sizing_mode="stretch_both"),
-    sizing_mode="stretch_width",
+    sizing_mode="stretch_both",
     min_height=250,
 )
 

--- a/tests/test_bidirectional_communication.py
+++ b/tests/test_bidirectional_communication.py
@@ -1,0 +1,253 @@
+"""
+Test Panel app for bidirectional postMessage communication with ephys_gui_app.
+
+Start the ephys_gui_app server on port 6000, then serve this file:
+
+    panel serve tests/test_bidirectional_communication.py --port 5007 --allow-websocket-origin="*"
+
+Each iframe loads the GUI with a different identifier (0000 / 0001).
+The parent app can receive curation data from either iframe and send
+curation data back to a chosen iframe.
+"""
+
+import json
+import datetime
+
+import urllib.parse
+
+import panel as pn
+from panel.custom import ReactComponent
+from panel.param import param
+
+pn.extension()
+
+EPHYS_GUI_PORT = 5006
+ANALYZER_PATH="s3://codeocean-s3datasetsbucket-1u41qdg42ur9/543979ee-17bd-41af-a504-e94a1de2ac40/postprocessed/experiment1_Record Node 104#Neuropix-PXI-100.ProbeA_recording1_group0.zarr"
+IDENTIFIERS = ["0000", "0001"]
+
+
+# ── Receive: listen for "panel-data" messages coming from the iframes ────────
+
+class ParentPostMessageListener(ReactComponent):
+    """
+    Listens on the *parent* window for postMessage events of type ``panel-data``
+    sent by the embedded ephys_gui_app iframes and forwards them to Python.
+    """
+
+    accept_type = param.String(default="panel-data")
+
+    _esm = """
+    export function render({ model }) {
+      const [acceptType] = model.useState("accept_type");
+
+      function onMessage(event) {
+        const data = event.data;
+        if (!data || data.source === "react-devtools-content-script") return;
+        if (acceptType && data.type !== acceptType) return;
+        model.send_msg({ payload: data, _ts: Date.now() });
+      }
+
+      React.useEffect(() => {
+        window.addEventListener("message", onMessage);
+        return () => window.removeEventListener("message", onMessage);
+      }, [acceptType]);
+
+      return <></>;
+    }
+    """
+
+
+# ── Send: postMessage into a specific iframe ─────────────────────────────────
+
+class IFramePostMessageSender(ReactComponent):
+    """
+    Invisible component that, whenever *message_json* changes, posts a
+    ``curation-data`` message into the iframe whose id matches *target_iframe_id*.
+    """
+
+    message_json = param.String(default="")
+    target_iframe_id = param.String(default="")
+
+    _esm = """
+    export function render({ model }) {
+      const [messageJson] = model.useState("message_json");
+      const [targetId]    = model.useState("target_iframe_id");
+
+      React.useEffect(() => {
+        if (!messageJson) return;
+
+        // Strip the timestamp suffix we append to force change detection
+        const lastUnderscore = messageJson.lastIndexOf("_");
+        const raw = lastUnderscore > 0 ? messageJson.substring(0, lastUnderscore) : messageJson;
+        if (!raw) return;
+
+        try {
+          const parsed = JSON.parse(raw);
+          const iframe = document.getElementById(targetId);
+          if (iframe && iframe.contentWindow) {
+            iframe.contentWindow.postMessage(parsed, "*");
+            console.log(`[parent] Sent to iframe#${targetId}:`, parsed);
+          } else {
+            console.warn(`[parent] iframe#${targetId} not found`);
+          }
+        } catch (err) {
+          console.error("[parent] JSON parse error:", err);
+        }
+      }, [messageJson]);
+
+      return <></>;
+    }
+    """
+
+
+# ── Build IFrame URLs ────────────────────────────────────────────────────────
+
+def iframe_url(identifier: str) -> str:
+    return (
+        f"http://localhost:{EPHYS_GUI_PORT}/ephys_gui_app"
+        f"?analyzer_path={urllib.parse.quote(ANALYZER_PATH)}&"
+        f"recording_path=&identifier={identifier}&fast_mode=true"
+    )
+
+
+# ── Layout ────────────────────────────────────────────────────────────────────
+
+# Iframes
+print("Loading iframes with URLs:")
+print(f"iframe-0000: {iframe_url('0000')}")
+print(f"iframe-0001: {iframe_url('0001')}")
+iframe_0000 = pn.pane.HTML(
+    f'<iframe id="iframe-0000" src="{iframe_url("0000")}" '
+    f'style="width:100%;height:100%;border:2px solid #2A7DE1;border-radius:6px;" '
+    f'allow="cross-origin-isolated"></iframe>',
+    sizing_mode="stretch_both",
+    min_height=500,
+)
+iframe_0001 = pn.pane.HTML(
+    f'<iframe id="iframe-0001" src="{iframe_url("0001")}" '
+    f'style="width:100%;height:100%;border:2px solid #1D8649;border-radius:6px;" '
+    f'allow="cross-origin-isolated"></iframe>',
+    sizing_mode="stretch_both",
+    min_height=500,
+)
+
+# Received-messages log
+received_log = pn.widgets.TextAreaInput(
+    name="📩  Received curation messages",
+    value="",
+    placeholder="Messages from iframes will appear here…",
+    sizing_mode="stretch_both",
+    min_height=200,
+    disabled=True,
+)
+
+# PostMessage listener (parent-level)
+listener = ParentPostMessageListener()
+
+
+def _on_receive(msg):
+    """Callback fired when a panel-data message arrives from any iframe."""
+    payload = msg.get("payload", {})
+    identifier = payload.get("identifier", "???")
+    data = payload.get("data", "")
+    ts = datetime.datetime.now().strftime("%H:%M:%S")
+    entry = f"[{ts}]  ── identifier: {identifier} ──\n{json.dumps(data, indent=2)}\n{'─' * 50}\n"
+    received_log.value = entry + received_log.value
+
+
+listener.on_msg(_on_receive)
+
+# ── Send controls ────────────────────────────────────────────────────────────
+
+target_select = pn.widgets.Select(
+    name="Target identifier",
+    options=IDENTIFIERS,
+    value=IDENTIFIERS[0],
+    width=160,
+)
+
+send_textarea = pn.widgets.TextAreaInput(
+    name="✏️  Curation data to send (JSON)",
+    value='{"manual_labels": [{"unit_id": 0, "quality": ["good"]}]}',
+    sizing_mode="stretch_width",
+    min_height=120,
+)
+
+send_button = pn.widgets.Button(name="Send ➤", button_type="primary", width=120)
+
+sender = IFramePostMessageSender()
+
+_send_counter = [0]
+
+
+def _on_send(event):
+    """Build a curation-data postMessage payload and push it into the sender."""
+    identifier = target_select.value
+    raw = send_textarea.value.strip()
+    if not raw:
+        return
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        received_log.value = f"⚠️  Invalid JSON: {exc}\n" + received_log.value
+        return
+
+    envelope = {
+        "type": "curation-data",
+        "identifier": identifier,
+        "data": data,
+    }
+
+    sender.target_iframe_id = f"iframe-{identifier}"
+    # Append a unique counter so the param change always fires
+    _send_counter[0] += 1
+    sender.message_json = json.dumps(envelope) + f"_{_send_counter[0]}"
+
+    ts = datetime.datetime.now().strftime("%H:%M:%S")
+    received_log.value = (
+        f"[{ts}]  ▶ SENT to {identifier}\n"
+        f"{json.dumps(data, indent=2)}\n{'─' * 50}\n"
+        + received_log.value
+    )
+
+
+send_button.on_click(_on_send)
+
+# ── Assemble ──────────────────────────────────────────────────────────────────
+
+header = pn.pane.Markdown(
+    "# 🔬 Bidirectional Communication Test\n"
+    f"Iframes point to `localhost:{EPHYS_GUI_PORT}` — make sure the ephys_gui_app server is running.",
+    sizing_mode="stretch_width",
+)
+
+iframes_row = pn.Row(
+    pn.Column("### iframe 0000", iframe_0000, sizing_mode="stretch_both"),
+    pn.Column("### iframe 0001", iframe_0001, sizing_mode="stretch_both"),
+    sizing_mode="stretch_both",
+    min_height=500,
+)
+
+send_panel = pn.Column(
+    pn.Row(target_select, send_button, align="end"),
+    send_textarea,
+    sizing_mode="stretch_width",
+)
+
+comm_row = pn.Row(
+    pn.Column("### Send", send_panel, sizing_mode="stretch_both"),
+    pn.Column("### Receive", received_log, sizing_mode="stretch_both"),
+    sizing_mode="stretch_width",
+    min_height=250,
+)
+
+layout = pn.Column(
+    header,
+    iframes_row,
+    comm_row,
+    listener,   # invisible – just needs to be in the document
+    sender,     # invisible – just needs to be in the document
+    sizing_mode="stretch_both",
+)
+
+layout.servable(title="Bidirectional Communication Test")

--- a/tests/test_bidirectional_communication.py
+++ b/tests/test_bidirectional_communication.py
@@ -30,11 +30,11 @@ IDENTIFIERS = ["0000", "0001"]
 
 class ParentPostMessageListener(ReactComponent):
     """
-    Listens on the *parent* window for postMessage events of type ``panel-data``
+    Listens on the *parent* window for postMessage events of type ``curation-data``
     sent by the embedded ephys_gui_app iframes and forwards them to Python.
     """
 
-    accept_type = param.String(default="panel-data")
+    accept_type = param.String(default="curation-data")
 
     _esm = """
     export function render({ model }) {
@@ -159,7 +159,7 @@ listener = ParentPostMessageListener()
 
 
 def _on_receive(msg):
-    """Callback fired when a panel-data message arrives from any iframe."""
+    """Callback fired when a curation-data message arrives from any iframe."""
     data = msg.data
     payload = data.get("payload", {})
     identifier = payload.get("identifier", "???")


### PR DESCRIPTION
This PR adds the `identifier` field to the settings that can be set by URL.

This allows each instance of the Ephys GUI to:
1. add the identifier field when sending a postMessage to a parent window
2. filter incoming curation data by identifier, so that a parent app doesn't need to target a specify iframe but can just broadcast the curation message to all existing iframes in the DOM + Shadow DOM

Here is a short video showcasing this, using the [`test_bidirectional_communication.py`](https://github.com/AllenNeuralDynamics/aind-ephys-portal/blob/expose-id/tests/test_bidirectional_communication.py):
- 2 iframes are in 2 tabs (identifiers: 0000/0001)
- submitting curation data form the iframe carries identifiers information
- when sending curation data with the `identifier` field the curation is only applied to the right iframe

https://github.com/user-attachments/assets/e93cefda-3a5d-4f7a-a8ef-a4472b0224e8

