### PR TITLE
fix: bump up memory when max sessions are reached, not exceeded

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -59,9 +59,9 @@ class HealthHandler(RequestHandler):
                 f"Busy (RAM Usage):\nMemory at {mem_percent:.1f}% - Num sessions: {len(gui_sessions)} "
                 f"(max {max_gui_sessions}) Task ID: {task_id}"
             )
-        elif len(gui_sessions) > max_gui_sessions:
+        elif len(gui_sessions) >= max_gui_sessions:
             self.set_status(200)
-            busy_msg = "(MAX SESSIONS EXCEEDED)"
+            busy_msg = "(MAX SESSIONS REACHED)"
             if _tmp_arr is not None:
                 busy_msg += " (inflating memory)"
             elif _tmp_array_triggered:


### PR DESCRIPTION
In https://github.com/AllenNeuralDynamics/aind-ephys-portal/pull/28 the number of GUI session is not increased if the GUI session is beyond the max number of allwoed sessions. We therefore need to bump up  RAM usage to request ECS up-scaling when the number of sessions reaches mac number of sessions, not if it's more than that