### PR TITLE
Enhance memory debug diagnostics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,13 @@ RUN pip install spikeinterface==0.104.1
 # Install spikeinterface-gui from source
 RUN pip install spikeinterface-gui==0.13.1
 
+# Pin scikit-learn AFTER spikeinterface installs so we override whatever the
+# transitive resolver picked. Match the version that analyzers in our pipeline
+# are saved with — version mismatches trigger sklearn's InconsistentVersionWarning,
+# which is then constructed with a positional arg by buggy upstream code and
+# crashes session init (TypeError: __init__() takes 1 positional argument but 2).
+RUN pip install scikit-learn==1.8.0
+
 ENV PYTHONUNBUFFERED=1
 # Limit glibc malloc arenas to reduce per-thread heap fragmentation.
 # Default is 8 * NCPU; with numpy/zarr large alloc + free patterns this

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ RUN pip install spikeinterface==0.104.1
 RUN pip install spikeinterface-gui==0.13.1
 
 ENV PYTHONUNBUFFERED=1
+# Limit glibc malloc arenas to reduce per-thread heap fragmentation.
+# Default is 8 * NCPU; with numpy/zarr large alloc + free patterns this
+# leaves freed pages stranded across many arenas, inflating RSS.
+ENV MALLOC_ARENA_MAX=2
 
 EXPOSE 8000
 ENTRYPOINT ["python", "entrypoint.py", "--address", "0.0.0.0", "--port", "8000"]

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,16 +1,25 @@
+import gc
 import os
 import shutil
 import threading
+import tracemalloc
 from argparse import ArgumentParser
+from collections import Counter
 
 import numpy as np
 import psutil
 import panel as pn
 from tornado.web import RequestHandler
 
+# Start tracemalloc as early as possible so allocation tracebacks include the
+# session-loading code paths. Frame depth 10 is enough to identify the call site
+# inside spikeinterface/zarr/fsspec without blowing up memory overhead.
+tracemalloc.start(10)
+_tracemalloc_baseline = tracemalloc.take_snapshot()
+
 # 1. Run setup (replaces --setup flag)
-from aind_ephys_portal.setup import *  # noqa: F401,F403
-from aind_ephys_portal.panel.logging import (
+from aind_ephys_portal.setup import *  # noqa: F401,F403,E402
+from aind_ephys_portal.panel.logging import (  # noqa: E402
     list_gui_sessions,
     get_max_number_of_gui_sessions,
     get_container_total_memory,
@@ -22,6 +31,13 @@ from aind_ephys_portal.panel.logging import (
 TARGET_MEMORY_TRIGGER_PERCENT = 70
 TARGET_CLEAR_TMP_ARR_SECONDS = 180
 TARGET_INFLATE_DELAY_SECONDS = 90
+
+# Recycle signal: when a task is sitting idle (0 GUI sessions) but its RAM
+# stays above this percent, /health returns 503 so the ALB deregisters it and
+# the ECS service scheduler replaces it. Baseline (no sessions, fresh start)
+# is ~10%, so 40% means tolerating ~30 points of accumulated residue before
+# recycling. Only triggers with 0 sessions, so user sessions are never cut.
+RECYCLE_RAM_PERCENT_WHEN_IDLE = 40
 
 
 if LOG_DIR.is_dir():
@@ -76,6 +92,16 @@ class HealthHandler(RequestHandler):
         task_id = get_ecs_task_id()
         max_gui_sessions = get_max_number_of_gui_sessions()
 
+        # Idle-but-bloated → ask ALB to deregister so ECS replaces us.
+        # GUI-level enforcement protects against admitting too many sessions,
+        # but only the load balancer can take a leaky task out of rotation.
+        if len(gui_sessions) == 0 and mem_percent > RECYCLE_RAM_PERCENT_WHEN_IDLE:
+            self.set_status(503)
+            self.write(
+                f"Unhealthy (recycle): Memory at {mem_percent:.1f}% with 0 sessions - Task ID: {task_id}"
+            )
+            return
+
         if mem_percent > TARGET_MEMORY_TRIGGER_PERCENT:
             self.set_status(200)
             self.write(
@@ -122,6 +148,99 @@ class HealthHandler(RequestHandler):
 class IndexRedirectHandler(RequestHandler):
     def get(self):
         self.redirect("/ephys_portal_app")
+
+
+class DebugMemoryHandler(RequestHandler):
+    """Live introspection for diagnosing memory retention on a bloated task.
+
+    Returns top object counts (via gc.get_objects), top allocation sites
+    (tracemalloc snapshot diff vs. boot baseline), and fsspec/s3fs instance
+    cache sizes. Gated by DEBUG_MEMORY_TOKEN env var to avoid exposing
+    process internals publicly.
+    """
+
+    def get(self):
+        token = os.environ.get("DEBUG_MEMORY_TOKEN")
+        if token and self.request.headers.get("X-Debug-Token") != token:
+            self.set_status(401)
+            self.write("Unauthorized: missing or wrong X-Debug-Token header")
+            return
+
+        task_id = get_ecs_task_id()
+        total_memory = get_container_total_memory()
+        used_memory = get_container_used_memory()
+        mem_percent = used_memory / total_memory * 100
+        gui_sessions = list_gui_sessions()
+
+        # Force a collection so we don't count obviously-dead objects.
+        gc.collect()
+        gc.collect()
+
+        # 1) Object counts by type (top 30 by count)
+        type_counts = Counter()
+        for obj in gc.get_objects():
+            type_counts[type(obj).__name__] += 1
+        top_types = type_counts.most_common(30)
+
+        # 2) numpy/zarr/pandas big buffers — sum bytes by type
+        big_buffers = []
+        try:
+            import numpy as _np
+
+            np_bytes = 0
+            np_count = 0
+            for obj in gc.get_objects():
+                if isinstance(obj, _np.ndarray):
+                    np_bytes += obj.nbytes
+                    np_count += 1
+            big_buffers.append(("numpy.ndarray", np_count, np_bytes))
+        except Exception as e:
+            big_buffers.append(("numpy.ndarray", -1, -1))
+
+        # 3) fsspec/s3fs cache state
+        fsspec_info = []
+        try:
+            from fsspec import AbstractFileSystem
+
+            fsspec_info.append(
+                f"fsspec AbstractFileSystem._cache size: {len(AbstractFileSystem._cache)}"
+            )
+            for key, fs in list(AbstractFileSystem._cache.items())[:10]:
+                fsspec_info.append(f"  - {type(fs).__name__}: protocol={getattr(fs, 'protocol', '?')}")
+        except Exception as e:
+            fsspec_info.append(f"fsspec inspection failed: {e}")
+
+        # 4) tracemalloc top allocators since boot baseline
+        tm_lines = []
+        try:
+            current = tracemalloc.take_snapshot()
+            stats = current.compare_to(_tracemalloc_baseline, "lineno")[:25]
+            for stat in stats:
+                tm_lines.append(
+                    f"  +{stat.size_diff/1024/1024:7.2f} MiB ({stat.count_diff:+d} blocks)  {stat.traceback[0]}"
+                )
+        except Exception as e:
+            tm_lines.append(f"tracemalloc unavailable: {e}")
+
+        self.set_header("Content-Type", "text/plain; charset=utf-8")
+        out = [
+            f"=== Task {task_id} ===",
+            f"Memory: {mem_percent:.1f}%  ({used_memory/1024**3:.2f} / {total_memory/1024**3:.2f} GB)",
+            f"GUI sessions: {len(gui_sessions)}",
+            "",
+            "--- Top object types by count ---",
+        ]
+        for name, count in top_types:
+            out.append(f"  {count:>10d}  {name}")
+        out.extend(["", "--- Buffer bytes ---"])
+        for name, count, nbytes in big_buffers:
+            mib = nbytes / 1024 / 1024 if nbytes >= 0 else -1
+            out.append(f"  {name}: {count} objects, {mib:.1f} MiB")
+        out.extend(["", "--- fsspec ---"])
+        out.extend(fsspec_info)
+        out.extend(["", "--- tracemalloc (top 25 since boot) ---"])
+        out.extend(tm_lines)
+        self.write("\n".join(out))
 
 
 # 3. App file paths — Panel will exec these per-session with a proper context
@@ -182,7 +301,11 @@ if __name__ == "__main__":
         port=port,
         allow_websocket_origin=allow_ws,
         static_dirs={"images": os.path.join(APP_DIR, "images")},
-        extra_patterns=[(r"/health", HealthHandler), (r"/", IndexRedirectHandler)],
+        extra_patterns=[
+            (r"/health", HealthHandler),
+            (r"/debug/memory", DebugMemoryHandler),
+            (r"/", IndexRedirectHandler),
+        ],
         check_unused_sessions=2000,
         unused_session_lifetime=5000,
         show=False,

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -11,11 +11,20 @@ import psutil
 import panel as pn
 from tornado.web import RequestHandler
 
-# Start tracemalloc as early as possible so allocation tracebacks include the
-# session-loading code paths. Frame depth 10 is enough to identify the call site
-# inside spikeinterface/zarr/fsspec without blowing up memory overhead.
-tracemalloc.start(10)
-_tracemalloc_baseline = tracemalloc.take_snapshot()
+# tracemalloc is OFF by default. Recording a per-allocation Python traceback
+# adds non-trivial CPU overhead per allocation; on a Panel + spikeinterface
+# + zarr workload that slowed Tornado enough for ECS health checks to time
+# out, producing exit-137 restart loops. Enable only on diagnostic deploys:
+#   TRACEMALLOC_ENABLED=1  (and optionally TRACEMALLOC_DEPTH, default 4)
+_TRACEMALLOC_ENABLED = os.environ.get("TRACEMALLOC_ENABLED", "0").lower() in ("1", "true", "yes")
+_tracemalloc_baseline = None
+if _TRACEMALLOC_ENABLED:
+    _tm_depth = int(os.environ.get("TRACEMALLOC_DEPTH", "4"))
+    tracemalloc.start(_tm_depth)
+    _tracemalloc_baseline = tracemalloc.take_snapshot()
+    print(f"tracemalloc ENABLED with frame depth {_tm_depth}")
+else:
+    print("tracemalloc DISABLED (set TRACEMALLOC_ENABLED=1 to enable)")
 
 # 1. Run setup (replaces --setup flag)
 from aind_ephys_portal.setup import *  # noqa: F401,F403,E402
@@ -33,11 +42,11 @@ TARGET_CLEAR_TMP_ARR_SECONDS = 180
 TARGET_INFLATE_DELAY_SECONDS = 90
 
 # Recycle signal: when a task is sitting idle (0 GUI sessions) but its RAM
-# stays above this percent, /health returns 503 so the ALB deregisters it and
-# the ECS service scheduler replaces it. Baseline (no sessions, fresh start)
-# is ~10%, so 40% means tolerating ~30 points of accumulated residue before
-# recycling. Only triggers with 0 sessions, so user sessions are never cut.
-RECYCLE_RAM_PERCENT_WHEN_IDLE = 40
+# stays above this percent, /health returns 503 so the ALB deregisters it
+# and the ECS service scheduler replaces it. Overridable via env var so we
+# can tune without redeploys once we re-baseline post-rollback. Only
+# triggers with 0 sessions, so user sessions are never cut.
+RECYCLE_RAM_PERCENT_WHEN_IDLE = int(os.environ.get("RECYCLE_RAM_PERCENT_WHEN_IDLE", "50"))
 
 
 if LOG_DIR.is_dir():
@@ -212,15 +221,18 @@ class DebugMemoryHandler(RequestHandler):
 
         # 4) tracemalloc top allocators since boot baseline
         tm_lines = []
-        try:
-            current = tracemalloc.take_snapshot()
-            stats = current.compare_to(_tracemalloc_baseline, "lineno")[:25]
-            for stat in stats:
-                tm_lines.append(
-                    f"  +{stat.size_diff/1024/1024:7.2f} MiB ({stat.count_diff:+d} blocks)  {stat.traceback[0]}"
-                )
-        except Exception as e:
-            tm_lines.append(f"tracemalloc unavailable: {e}")
+        if not _TRACEMALLOC_ENABLED:
+            tm_lines.append("tracemalloc disabled (set TRACEMALLOC_ENABLED=1 to enable)")
+        else:
+            try:
+                current = tracemalloc.take_snapshot()
+                stats = current.compare_to(_tracemalloc_baseline, "lineno")[:25]
+                for stat in stats:
+                    tm_lines.append(
+                        f"  +{stat.size_diff/1024/1024:7.2f} MiB ({stat.count_diff:+d} blocks)  {stat.traceback[0]}"
+                    )
+            except Exception as e:
+                tm_lines.append(f"tracemalloc error: {e}")
 
         self.set_header("Content-Type", "text/plain; charset=utf-8")
         out = [

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,7 +1,9 @@
+import asyncio
 import gc
 import os
 import shutil
 import threading
+import time as _time
 import tracemalloc
 from argparse import ArgumentParser
 from collections import Counter
@@ -159,100 +161,136 @@ class IndexRedirectHandler(RequestHandler):
         self.redirect("/ephys_portal_app")
 
 
+# /debug/memory does heavy work (gc.collect + walking gc.get_objects, which
+# can iterate millions of objects). Doing that on the Tornado event loop
+# thread blocks /health for long enough to trip ECS health checks → task
+# gets replaced. So we (1) run the heavy work in an executor thread,
+# (2) allow only one in-flight build via a lock, and (3) cache the result
+# for a short TTL so polling clients don't repeatedly trigger the work.
+_DEBUG_MEM_LOCK = asyncio.Lock()
+_DEBUG_MEM_CACHE = {"ts": 0.0, "body": ""}
+_DEBUG_MEM_CACHE_TTL = 30.0  # seconds
+
+
+def _build_debug_memory_payload():
+    """Heavy synchronous work — must be called from an executor thread."""
+    task_id = get_ecs_task_id()
+    total_memory = get_container_total_memory()
+    used_memory = get_container_used_memory()
+    mem_percent = used_memory / total_memory * 100
+    gui_sessions = list_gui_sessions()
+
+    # One gc.collect() is enough — two was overkill and adds latency.
+    gc.collect()
+
+    # Single pass over gc.get_objects(): count types AND sum numpy bytes
+    # in one walk. Halves the time vs the previous two-pass version.
+    type_counts = Counter()
+    np_bytes = 0
+    np_count = 0
+    for obj in gc.get_objects():
+        type_counts[type(obj).__name__] += 1
+        if isinstance(obj, np.ndarray):
+            np_bytes += obj.nbytes
+            np_count += 1
+    top_types = type_counts.most_common(30)
+
+    # fsspec/s3fs cache state
+    fsspec_info = []
+    try:
+        from fsspec import AbstractFileSystem
+
+        fsspec_info.append(
+            f"fsspec AbstractFileSystem._cache size: {len(AbstractFileSystem._cache)}"
+        )
+        for key, fs in list(AbstractFileSystem._cache.items())[:10]:
+            fsspec_info.append(f"  - {type(fs).__name__}: protocol={getattr(fs, 'protocol', '?')}")
+    except Exception as e:
+        fsspec_info.append(f"fsspec inspection failed: {e}")
+
+    # tracemalloc top allocators since boot baseline
+    tm_lines = []
+    if not _TRACEMALLOC_ENABLED:
+        tm_lines.append("tracemalloc disabled (set TRACEMALLOC_ENABLED=1 to enable)")
+    else:
+        try:
+            current = tracemalloc.take_snapshot()
+            stats = current.compare_to(_tracemalloc_baseline, "lineno")[:25]
+            for stat in stats:
+                tm_lines.append(
+                    f"  +{stat.size_diff/1024/1024:7.2f} MiB ({stat.count_diff:+d} blocks)  {stat.traceback[0]}"
+                )
+        except Exception as e:
+            tm_lines.append(f"tracemalloc error: {e}")
+
+    out = [
+        f"=== Task {task_id} ===",
+        f"Memory: {mem_percent:.1f}%  ({used_memory/1024**3:.2f} / {total_memory/1024**3:.2f} GB)",
+        f"GUI sessions: {len(gui_sessions)}",
+        "",
+        "--- Top object types by count ---",
+    ]
+    for name, count in top_types:
+        out.append(f"  {count:>10d}  {name}")
+    out.extend(["", "--- Buffer bytes ---"])
+    mib = np_bytes / 1024 / 1024
+    out.append(f"  numpy.ndarray: {np_count} objects, {mib:.1f} MiB")
+    out.extend(["", "--- fsspec ---"])
+    out.extend(fsspec_info)
+    out.extend(["", "--- tracemalloc (top 25 since boot) ---"])
+    out.extend(tm_lines)
+    return "\n".join(out)
+
+
 class DebugMemoryHandler(RequestHandler):
     """Live introspection for diagnosing memory retention on a bloated task.
 
     Returns top object counts (via gc.get_objects), top allocation sites
     (tracemalloc snapshot diff vs. boot baseline), and fsspec/s3fs instance
-    cache sizes. Gated by DEBUG_MEMORY_TOKEN env var to avoid exposing
-    process internals publicly.
+    cache sizes. Gated by DEBUG_MEMORY_TOKEN env var. Heavy work runs in a
+    thread executor with a 1-in-flight lock and a 30s result cache so the
+    Tornado event loop stays free to answer /health.
     """
 
-    def get(self):
+    async def get(self):
         token = os.environ.get("DEBUG_MEMORY_TOKEN")
         if token and self.request.headers.get("X-Debug-Token") != token:
             self.set_status(401)
             self.write("Unauthorized: missing or wrong X-Debug-Token header")
             return
 
-        task_id = get_ecs_task_id()
-        total_memory = get_container_total_memory()
-        used_memory = get_container_used_memory()
-        mem_percent = used_memory / total_memory * 100
-        gui_sessions = list_gui_sessions()
+        # Serve cached result if fresh.
+        now = _time.monotonic()
+        if _DEBUG_MEM_CACHE["body"] and now - _DEBUG_MEM_CACHE["ts"] < _DEBUG_MEM_CACHE_TTL:
+            self.set_header("Content-Type", "text/plain; charset=utf-8")
+            self.set_header("X-Debug-Cache", "hit")
+            age = now - _DEBUG_MEM_CACHE["ts"]
+            self.write(f"[cached snapshot, age {age:.1f}s — TTL {_DEBUG_MEM_CACHE_TTL:.0f}s]\n\n")
+            self.write(_DEBUG_MEM_CACHE["body"])
+            return
 
-        # Force a collection so we don't count obviously-dead objects.
-        gc.collect()
-        gc.collect()
+        # Reject pile-ups while a build is in flight. Caller can retry.
+        if _DEBUG_MEM_LOCK.locked():
+            self.set_status(429)
+            self.set_header("Retry-After", "5")
+            self.write("Another /debug/memory build is in flight; retry in a few seconds.")
+            return
 
-        # 1) Object counts by type (top 30 by count)
-        type_counts = Counter()
-        for obj in gc.get_objects():
-            type_counts[type(obj).__name__] += 1
-        top_types = type_counts.most_common(30)
-
-        # 2) numpy/zarr/pandas big buffers — sum bytes by type
-        big_buffers = []
-        try:
-            import numpy as _np
-
-            np_bytes = 0
-            np_count = 0
-            for obj in gc.get_objects():
-                if isinstance(obj, _np.ndarray):
-                    np_bytes += obj.nbytes
-                    np_count += 1
-            big_buffers.append(("numpy.ndarray", np_count, np_bytes))
-        except Exception as e:
-            big_buffers.append(("numpy.ndarray", -1, -1))
-
-        # 3) fsspec/s3fs cache state
-        fsspec_info = []
-        try:
-            from fsspec import AbstractFileSystem
-
-            fsspec_info.append(
-                f"fsspec AbstractFileSystem._cache size: {len(AbstractFileSystem._cache)}"
-            )
-            for key, fs in list(AbstractFileSystem._cache.items())[:10]:
-                fsspec_info.append(f"  - {type(fs).__name__}: protocol={getattr(fs, 'protocol', '?')}")
-        except Exception as e:
-            fsspec_info.append(f"fsspec inspection failed: {e}")
-
-        # 4) tracemalloc top allocators since boot baseline
-        tm_lines = []
-        if not _TRACEMALLOC_ENABLED:
-            tm_lines.append("tracemalloc disabled (set TRACEMALLOC_ENABLED=1 to enable)")
-        else:
-            try:
-                current = tracemalloc.take_snapshot()
-                stats = current.compare_to(_tracemalloc_baseline, "lineno")[:25]
-                for stat in stats:
-                    tm_lines.append(
-                        f"  +{stat.size_diff/1024/1024:7.2f} MiB ({stat.count_diff:+d} blocks)  {stat.traceback[0]}"
-                    )
-            except Exception as e:
-                tm_lines.append(f"tracemalloc error: {e}")
+        async with _DEBUG_MEM_LOCK:
+            # Re-check the cache: another request may have populated it
+            # while we were waiting on the lock.
+            now = _time.monotonic()
+            if _DEBUG_MEM_CACHE["body"] and now - _DEBUG_MEM_CACHE["ts"] < _DEBUG_MEM_CACHE_TTL:
+                body = _DEBUG_MEM_CACHE["body"]
+            else:
+                loop = asyncio.get_event_loop()
+                body = await loop.run_in_executor(None, _build_debug_memory_payload)
+                _DEBUG_MEM_CACHE["ts"] = _time.monotonic()
+                _DEBUG_MEM_CACHE["body"] = body
 
         self.set_header("Content-Type", "text/plain; charset=utf-8")
-        out = [
-            f"=== Task {task_id} ===",
-            f"Memory: {mem_percent:.1f}%  ({used_memory/1024**3:.2f} / {total_memory/1024**3:.2f} GB)",
-            f"GUI sessions: {len(gui_sessions)}",
-            "",
-            "--- Top object types by count ---",
-        ]
-        for name, count in top_types:
-            out.append(f"  {count:>10d}  {name}")
-        out.extend(["", "--- Buffer bytes ---"])
-        for name, count, nbytes in big_buffers:
-            mib = nbytes / 1024 / 1024 if nbytes >= 0 else -1
-            out.append(f"  {name}: {count} objects, {mib:.1f} MiB")
-        out.extend(["", "--- fsspec ---"])
-        out.extend(fsspec_info)
-        out.extend(["", "--- tracemalloc (top 25 since boot) ---"])
-        out.extend(tm_lines)
-        self.write("\n".join(out))
+        self.set_header("X-Debug-Cache", "miss")
+        self.write(body)
 
 
 # 3. App file paths — Panel will exec these per-session with a proper context

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -208,10 +208,14 @@ def _build_debug_memory_payload():
     except Exception as e:
         fsspec_info.append(f"fsspec inspection failed: {e}")
 
-    # tracemalloc top allocators since boot baseline
+    # tracemalloc top allocators since the recorded baseline. Use is_tracing()
+    # so runtime POST /debug/tracemalloc/{start,stop} toggles are reflected
+    # automatically — no need to read a separate module-level flag.
     tm_lines = []
-    if not _TRACEMALLOC_ENABLED:
-        tm_lines.append("tracemalloc disabled (set TRACEMALLOC_ENABLED=1 to enable)")
+    if not tracemalloc.is_tracing():
+        tm_lines.append("tracemalloc disabled (POST /debug/tracemalloc/start to enable)")
+    elif _tracemalloc_baseline is None:
+        tm_lines.append("tracemalloc tracing, but no baseline snapshot yet")
     else:
         try:
             current = tracemalloc.take_snapshot()
@@ -293,6 +297,78 @@ class DebugMemoryHandler(RequestHandler):
         self.write(body)
 
 
+def _check_debug_token(handler):
+    """Returns True if request is authorized, otherwise writes 401 and returns False."""
+    token = os.environ.get("DEBUG_MEMORY_TOKEN")
+    if token and handler.request.headers.get("X-Debug-Token") != token:
+        handler.set_status(401)
+        handler.write("Unauthorized: missing or wrong X-Debug-Token header")
+        return False
+    return True
+
+
+class TracemallocStartHandler(RequestHandler):
+    """POST /debug/tracemalloc/start?depth=4 — turn tracemalloc on at runtime.
+
+    Captures a fresh baseline snapshot so subsequent /debug/memory shows
+    allocations made AFTER this point. Only affects the task this request
+    lands on (each ECS task is its own process). Token-gated.
+    """
+
+    def post(self):
+        if not _check_debug_token(self):
+            return
+        global _tracemalloc_baseline
+        try:
+            depth = int(self.get_argument("depth", "4"))
+        except ValueError:
+            self.set_status(400)
+            self.write("depth must be an integer")
+            return
+        if depth < 1 or depth > 25:
+            self.set_status(400)
+            self.write("depth must be between 1 and 25")
+            return
+
+        task_id = get_ecs_task_id()
+        if tracemalloc.is_tracing():
+            # Already running — refresh the baseline so the next /debug/memory
+            # diffs against "now" instead of an old snapshot.
+            _tracemalloc_baseline = tracemalloc.take_snapshot()
+            _DEBUG_MEM_CACHE["body"] = ""  # invalidate stale cached output
+            self.write(
+                f"tracemalloc already tracing on task {task_id}. "
+                f"Baseline refreshed (depth unchanged).\n"
+            )
+            return
+
+        tracemalloc.start(depth)
+        _tracemalloc_baseline = tracemalloc.take_snapshot()
+        _DEBUG_MEM_CACHE["body"] = ""
+        self.write(f"tracemalloc STARTED on task {task_id} with depth {depth}\n")
+
+
+class TracemallocStopHandler(RequestHandler):
+    """POST /debug/tracemalloc/stop — turn tracemalloc off at runtime.
+
+    Frees the bookkeeping memory tracemalloc accumulates. Only affects the
+    task this request lands on. Token-gated.
+    """
+
+    def post(self):
+        if not _check_debug_token(self):
+            return
+        global _tracemalloc_baseline
+        task_id = get_ecs_task_id()
+        if not tracemalloc.is_tracing():
+            self.write(f"tracemalloc was already stopped on task {task_id}\n")
+            return
+        tracemalloc.stop()
+        _tracemalloc_baseline = None
+        _DEBUG_MEM_CACHE["body"] = ""
+        self.write(f"tracemalloc STOPPED on task {task_id}\n")
+
+
 # 3. App file paths — Panel will exec these per-session with a proper context
 APP_DIR = "src/aind_ephys_portal"
 apps = {
@@ -354,6 +430,8 @@ if __name__ == "__main__":
         extra_patterns=[
             (r"/health", HealthHandler),
             (r"/debug/memory", DebugMemoryHandler),
+            (r"/debug/tracemalloc/start", TracemallocStartHandler),
+            (r"/debug/tracemalloc/stop", TracemallocStopHandler),
             (r"/", IndexRedirectHandler),
         ],
         check_unused_sessions=2000,

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -23,9 +23,18 @@ from aind_ephys_portal.panel.logging import (
     get_max_number_of_gui_sessions,
     list_gui_sessions,
     get_ecs_task_id,
+    get_container_total_memory,
+    get_container_used_memory,
     remove_session,
 )
 from aind_ephys_portal.panel.utils import PostMessageListener, FullscreenResizeHandler
+
+# Refuse to admit a new session if the task's RAM is already above this percent,
+# regardless of how many sessions are active. Protects "poisoned" tasks
+# (residue from prior sessions) from being pushed into OOM by the count-based
+# admission rule. Picked below the /health 503 recycle threshold so the ALB
+# pulls the task out of rotation before the GUI starts rejecting.
+MAX_RAM_PERCENT_FOR_NEW_SESSION = 55
 
 displayed_unit_properties = [
     "decoder_label",
@@ -78,6 +87,47 @@ def _malloc_trim():
         pass
 
 
+def _clear_fsspec_instance_caches():
+    """Drop cached fsspec filesystem instances and their internal block buffers.
+
+    fsspec keeps every filesystem ever constructed in AbstractFileSystem._cache,
+    so per-instance invalidate_cache() (dir listings) doesn't release the FS
+    itself or its dircache/block buffers. We only drop instances with no other
+    referrers to avoid stealing FS objects from concurrent sessions.
+    """
+    try:
+        import sys
+        from fsspec import AbstractFileSystem
+    except Exception:
+        return
+
+    cache = getattr(AbstractFileSystem, "_cache", None)
+    if not cache:
+        return
+
+    # 2 = the local var here + sys.getrefcount's own arg ref → no external holders.
+    # If anything else has a handle, leave it alone.
+    removed = 0
+    for key in list(cache.keys()):
+        fs = cache.get(key)
+        if fs is None:
+            continue
+        if sys.getrefcount(fs) <= 3:  # cache dict + local + getrefcount arg
+            try:
+                # Drop any caches the FS exposes before dropping the FS.
+                for attr in ("dircache", "_intrans", "_open_files"):
+                    try:
+                        getattr(fs, attr, {}).clear()
+                    except Exception:
+                        pass
+                del cache[key]
+                removed += 1
+            except Exception:
+                pass
+    if removed:
+        print(f"Dropped {removed} idle fsspec filesystem instance(s) from cache.")
+
+
 class EphysGuiView(param.Parameterized):
 
     def __init__(
@@ -126,20 +176,26 @@ class EphysGuiView(param.Parameterized):
 
         num_gui_sessions = len(list_gui_sessions())
         max_sessions = get_max_number_of_gui_sessions()
-        if num_gui_sessions > max_sessions:
+        ram_percent = get_container_used_memory() / get_container_total_memory() * 100
+        too_many_sessions = num_gui_sessions > max_sessions
+        too_much_ram = ram_percent > MAX_RAM_PERCENT_FOR_NEW_SESSION
+        if too_many_sessions or too_much_ram:
             # Remove this session from the count — it is being rejected
             doc = pn.state.curdoc
             route = getattr(doc, "_log_route", None)
             session_id = getattr(doc, "_log_session_id", None)
             if route and session_id:
                 remove_session(route, session_id)
-            print(
-                f"Current number of GUI sessions: {num_gui_sessions}. Max allowed per worker: {max_sessions}. Task ID: {task_id}"
+            reason = (
+                f"too many sessions ({num_gui_sessions}/{max_sessions})"
+                if too_many_sessions
+                else f"task RAM already at {ram_percent:.1f}% (limit {MAX_RAM_PERCENT_FOR_NEW_SESSION}%)"
             )
+            print(f"Rejecting new session: {reason}. Task ID: {task_id}")
             self.layout = pn.Column(
                 header,
                 pn.pane.Markdown(
-                    f"⚠️ Too many active GUI sessions ({num_gui_sessions}). Max allowed per worker is {max_sessions}. "
+                    f"⚠️ Cannot start a new GUI session: {reason}. "
                     f"Please try again in a few minutes or open a new tab (Task ID: `{task_id}`).",
                     sizing_mode="stretch_both",
                 ),
@@ -543,6 +599,8 @@ class EphysGuiView(param.Parameterized):
             def _deferred_gc():
                 gc.collect()
                 gc.collect()
+                _clear_fsspec_instance_caches()
+                gc.collect()
                 _malloc_trim()
                 final_mem = psutil.virtual_memory()
                 used = final_mem.used / (1024**3)
@@ -553,6 +611,8 @@ class EphysGuiView(param.Parameterized):
         except Exception:
             # Fallback: run immediately if IOLoop is unavailable
             gc.collect()
+            gc.collect()
+            _clear_fsspec_instance_caches()
             gc.collect()
             _malloc_trim()
             final_mem = psutil.virtual_memory()

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -1,5 +1,6 @@
 import ctypes
 import json
+import os
 import psutil
 import param
 import time
@@ -77,6 +78,12 @@ aind_layout = dict(
     zone7=["waveform"],
     zone8=["correlogram", "metrics", "mainsettings"],
 )
+
+
+# Default OFF until we verify the refcount guard doesn't race with concurrent
+# sessions that may grab a cached fsspec FS microseconds after we check. Flip
+# via FSSPEC_DROP_INSTANCE_CACHE=1 once we have confidence.
+_FSSPEC_DROP_INSTANCE_CACHE = os.environ.get("FSSPEC_DROP_INSTANCE_CACHE", "0").lower() in ("1", "true", "yes")
 
 
 def _malloc_trim():
@@ -599,8 +606,9 @@ class EphysGuiView(param.Parameterized):
             def _deferred_gc():
                 gc.collect()
                 gc.collect()
-                _clear_fsspec_instance_caches()
-                gc.collect()
+                if _FSSPEC_DROP_INSTANCE_CACHE:
+                    _clear_fsspec_instance_caches()
+                    gc.collect()
                 _malloc_trim()
                 final_mem = psutil.virtual_memory()
                 used = final_mem.used / (1024**3)
@@ -612,8 +620,9 @@ class EphysGuiView(param.Parameterized):
             # Fallback: run immediately if IOLoop is unavailable
             gc.collect()
             gc.collect()
-            _clear_fsspec_instance_caches()
-            gc.collect()
+            if _FSSPEC_DROP_INSTANCE_CACHE:
+                _clear_fsspec_instance_caches()
+                gc.collect()
             _malloc_trim()
             final_mem = psutil.virtual_memory()
             used = final_mem.used / (1024**3)


### PR DESCRIPTION
# Make /debug/memory safe; add runtime tracemalloc toggle; pin sklearn

## Why

Two findings from yesterday's monitoring session drove this PR.

**1. The leak is real, path-dependent, and proportional to session weight.** Running 2 light sessions on a task → cleanup returns RAM to warm baseline (9.5%). Running 2 heavy sessions (full PCA + waveforms) → task strands ~17% of the loaded data (~2 GB residue) after cleanup. Over 5–6 rounds, that builds to the 11 GB/zero-sessions state we saw originally. So we need finer instrumentation to identify what's stranded.

**2. The previous `/debug/memory` was a footgun.** It ran `gc.collect()` + walked all of `gc.get_objects()` on the Tornado event loop thread. A single call blocked `/health` for 10–20 s, which trips ECS health checks → SIGKILL (exit 137). Killed one task this way during testing.

## Changes

### `/debug/memory` is now safe to call anytime
- Heavy work (gc walk, tracemalloc snapshot) runs in a thread executor — event loop stays free for `/health`.
- `asyncio.Lock` allows only one in-flight build; concurrent callers get HTTP 429 with `Retry-After`.
- Results cached for 30 s — repeated polling returns the cached snapshot without re-running the walk.
- Single-pass walk: counts object types AND sums `numpy.ndarray` bytes in one iteration (was two passes before).

### Runtime tracemalloc toggle (no redeploy needed)
- `POST /debug/tracemalloc/start?depth=4` — turns tracing on for the task this request lands on, captures fresh baseline. Calling again while running just refreshes the baseline.
- `POST /debug/tracemalloc/stop` — turns it off, releases bookkeeping memory.
- Both token-gated via `X-Debug-Token` header / `DEBUG_MEMORY_TOKEN` env var.
- `/debug/memory` now reads `tracemalloc.is_tracing()` directly so toggle state is reflected immediately.
- Needed because we don't have permissions to flip the `TRACEMALLOC_ENABLED` env var on the ECS task definition; this lets us instrument a single task on demand.

### Pin `scikit-learn==1.8.0` in Dockerfile
- Currently unpinned → pip resolves to whatever (in production: 1.7.2).
- Analyzers in the pipeline are saved with sklearn 1.8.0 → version mismatch on load → sklearn emits `InconsistentVersionWarning` → buggy upstream code (probably in spikeinterface_gui) constructs it with a positional arg, which crashes (`__init__() takes 1 positional argument but 2 were given`) because that warning class is kwarg-only.
- Sporadic — only fires on sessions that load the PCA extension.
- Pinned after `pip install spikeinterface-gui` in the Dockerfile so it overrides whatever the transitive resolver picked.
- Long-term fix is upstream; this is the immediate mitigation.

## Usage workflow once deployed

```bash
# Find a fresh task you want to instrument
curl https://.../health   # note the Task ID

# Start tracing on whichever task the ALB routes you to (response confirms task ID)
curl -X POST -H "X-Debug-Token: $TOKEN" \
  'https://.../debug/tracemalloc/start?depth=4'

# Open 2 heavy GUI sessions, let them load, close them. ~5 min.

# Inspect — should show allocation hotspots for what's stranded
curl -H "X-Debug-Token: $TOKEN" https://.../debug/memory

# Turn off when done
curl -X POST -H "X-Debug-Token: $TOKEN" https://.../debug/tracemalloc/stop
```

## Risk
- The async `/debug/memory` change makes the endpoint *strictly safer* than before (was crash-prone, now isn't).
- Tracemalloc toggle endpoints are off by default and token-gated.
- sklearn pin is the most user-visible — if upstream pipelines ever save analyzers with a different sklearn, those will hit the same bug. Trade-off is acceptable: it fixes the common case now and surfaces any new mismatch immediately.

---

# Hotfix: gate diagnostic features behind env vars

## Why hotfix

Previous deploy caused ECS tasks to crash with exit 137 in a restart loop.
Root cause: `tracemalloc.start(10)` adds per-allocation CPU overhead so heavy
that Tornado's event loop couldn't answer ECS health checks in time → SIGKILL.
The recycle 503 and fsspec cache drop weren't the trigger but are gated too,
defensively, until we re-baseline.

## Hotfix changes

- **`tracemalloc` OFF by default**. Enable per-deploy via `TRACEMALLOC_ENABLED=1`
  (and optionally `TRACEMALLOC_DEPTH=N`, default 4 — much lighter than the prior
  depth-10 setting). `/debug/memory` still works without tracemalloc — object
  counts, `numpy.ndarray` byte totals, and `fsspec._cache` state are reported
  unconditionally; only the top-allocations section is gated.
- **Recycle threshold raised to 50%** and made env-var overridable via
  `RECYCLE_RAM_PERCENT_WHEN_IDLE`. Re-baseline can lower it later without code.
- **fsspec instance-cache drop gated** behind `FSSPEC_DROP_INSTANCE_CACHE=1`.
  Off by default until we verify the refcount guard doesn't race with
  concurrent sessions.
- `MALLOC_ARENA_MAX=2` and RAM-aware admission left unchanged — neither
  contributed to the regression and both are safe.

---

# Original PR description: Reduce per-task RAM retention and add live memory diagnostics

## Why

Tasks accumulate RAM across sessions: a task with **0 active GUI sessions** can sit at ~11 GB / 16 GB. Per-session cleanup is in place, but residue compounds — caused by a mix of glibc fragmentation, fsspec/s3fs filesystem instances cached process-wide, and possibly other holdovers we can't yet see. This PR adds structural mitigations *and* the instrumentation needed to identify what's left.

## Changes

### Structural mitigations
- **`MALLOC_ARENA_MAX=2`** in `Dockerfile`. Caps glibc heap arenas; numpy/zarr's large-alloc-then-free pattern strands pages across the default 8+ arenas and `malloc_trim` can't recover them.
- **fsspec instance-cache clearing** in `EphysGuiView.cleanup()` deferred-GC path. `fs.invalidate_cache()` only clears dir listings — the FS object stays in `AbstractFileSystem._cache` with its block buffers. Now we drop instances that have no external referrers (checked via `sys.getrefcount`) so we don't yank an FS used by a concurrent session.

### Self-healing
- **`/health` returns 503 when `RAM > 40% AND sessions == 0`**. The ALB deregisters idle-but-bloated tasks; the ECS service scheduler replaces them. Baseline is ~10%, so 40% tolerates ~30 points of accumulated residue before recycling. Never fires on tasks with active users.
- **RAM-aware session admission** in `EphysGuiView`. The existing `max_sessions` cap assumes fresh memory; a poisoned task at 11 GB would still admit 2 new sessions and OOM. Now also rejects when `RAM > 55%`. (Kept above the 40% recycle line so a clean task running 1 session can still admit a 2nd.)

### Diagnostics
- **`tracemalloc` started at process boot** with a baseline snapshot, before heavy imports.
- **`/debug/memory` endpoint** (gated by `X-Debug-Token` header / `DEBUG_MEMORY_TOKEN` env var) reporting:
  - Top 30 Python object types by count
  - Total `numpy.ndarray` byte footprint
  - `fsspec._cache` size and protocol of each cached filesystem
  - `tracemalloc` top 25 allocation deltas since boot

## How to use after deploy

1. Watch `/health` — idle-bloated tasks should now self-recycle on their own.
2. Catch a still-bloated task and `curl -H "X-Debug-Token: $TOKEN" .../debug/memory`. The tracemalloc top + numpy bytes will tell us whether residue is buffers (cache work needed), controller state (specific refs to chase), or pure allocator fragmentation (arena fix is the answer).
3. If the arena fix alone clears it, the 55%/40% thresholds can be relaxed.

## Risk

- The 503 path only triggers with 0 active sessions, so no user-visible disruption.
- fsspec cache drop is guarded by `getrefcount` to avoid pulling a shared FS out from under a live session.
- `MALLOC_ARENA_MAX=2` is a well-known tuning knob for Python servers; worst case it has no effect.
- `tracemalloc` overhead is modest (frame depth 10).
