### PR TITLE
Enhance session count to admit new sessions

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -33,6 +33,8 @@ from aind_ephys_portal.setup import *  # noqa: F401,F403,E402
 from aind_ephys_portal.panel.logging import (  # noqa: E402
     list_gui_sessions,
     get_max_number_of_gui_sessions,
+    can_admit_new_session,
+    get_hard_cap_sessions,
     get_container_total_memory,
     get_container_used_memory,
     get_ecs_task_id,
@@ -100,40 +102,45 @@ class HealthHandler(RequestHandler):
         mem_percent = used_memory / total_memory * 100
         # count number of GUI app sessions
         gui_sessions = list_gui_sessions()
+        num_sessions = len(gui_sessions)
         task_id = get_ecs_task_id()
-        max_gui_sessions = get_max_number_of_gui_sessions()
+        hard_cap = get_hard_cap_sessions()
 
         # Idle-but-bloated → ask ALB to deregister so ECS replaces us.
         # GUI-level enforcement protects against admitting too many sessions,
         # but only the load balancer can take a leaky task out of rotation.
-        if len(gui_sessions) == 0 and mem_percent > RECYCLE_RAM_PERCENT_WHEN_IDLE:
+        if num_sessions == 0 and mem_percent > RECYCLE_RAM_PERCENT_WHEN_IDLE:
             self.set_status(503)
             self.write(
                 f"Unhealthy (recycle): Memory at {mem_percent:.1f}% with 0 sessions - Task ID: {task_id}"
             )
             return
 
-        if mem_percent > TARGET_MEMORY_TRIGGER_PERCENT:
+        # "Operationally full" = at least one session AND can't fit another
+        # without crossing the safe RAM ceiling or hitting the hard count cap.
+        # This unifies the old (count-based) and RAM-based busy paths into one
+        # predicate that's accurate for both light and heavy sessions.
+        full = num_sessions > 0 and not can_admit_new_session(
+            current_count=num_sessions, used_pct=mem_percent
+        )
+
+        if full:
             self.set_status(200)
-            self.write(
-                f"Busy (RAM Usage):\nMemory at {mem_percent:.1f}% - Num sessions: {len(gui_sessions)} "
-                f"(max {max_gui_sessions}) Task ID: {task_id}"
-            )
-        elif len(gui_sessions) >= max_gui_sessions:
-            self.set_status(200)
-            # inflate RAM once per threshold-exceeded event so ECS spawns a new task;
-            # wait TARGET_INFLATE_DELAY_SECONDS first so existing sessions finish loading
+            # inflate RAM once per "full" event so ECS spawns a new task;
+            # wait TARGET_INFLATE_DELAY_SECONDS first so loading sessions
+            # have time to finish.
             if _tmp_arr is None and _inflate_delay_timer is None and not _tmp_array_triggered:
                 _tmp_array_triggered = True
                 print(
-                    f"Max sessions reached, will inflate memory in {TARGET_INFLATE_DELAY_SECONDS}s"
+                    f"Task is full ({num_sessions} sessions, {mem_percent:.1f}% RAM); "
+                    f"will inflate memory in {TARGET_INFLATE_DELAY_SECONDS}s"
                 )
                 _inflate_delay_timer = threading.Timer(
                     TARGET_INFLATE_DELAY_SECONDS, _inflate_memory
                 )
                 _inflate_delay_timer.daemon = True
                 _inflate_delay_timer.start()
-            busy_msg = "(MAX SESSIONS REACHED)"
+            busy_msg = "(FULL)"
             if _tmp_arr is not None:
                 busy_msg += " (inflating memory)"
             elif _inflate_delay_timer is not None:
@@ -141,8 +148,8 @@ class HealthHandler(RequestHandler):
             elif _tmp_array_triggered:
                 busy_msg += " (inflated memory released)"
             self.write(
-                f"Busy {busy_msg}:\nMemory at {mem_percent:.1f}% - Num sessions: {len(gui_sessions)} "
-                f"(max {max_gui_sessions}) Task ID: {task_id}"
+                f"Busy {busy_msg}:\nMemory at {mem_percent:.1f}% - Num sessions: {num_sessions} "
+                f"(hard cap {hard_cap}) Task ID: {task_id}"
             )
         else:
             _tmp_array_triggered = False
@@ -151,8 +158,8 @@ class HealthHandler(RequestHandler):
                 _inflate_delay_timer = None
             self.set_status(200)
             self.write(
-                f"Healthy:\nMemory at {mem_percent:.1f}% - Num sessions: {len(gui_sessions)} "
-                f"(max {max_gui_sessions}) Task ID: {task_id}"
+                f"Healthy:\nMemory at {mem_percent:.1f}% - Num sessions: {num_sessions} "
+                f"(hard cap {hard_cap}) Task ID: {task_id}"
             )
 
 

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -21,7 +21,10 @@ from spikeinterface.curation import validate_curation_dict
 from aind_ephys_portal.panel.logging import (
     setup_logging,
     local_log_context,
-    get_max_number_of_gui_sessions,
+    can_admit_new_session,
+    get_hard_cap_sessions,
+    get_per_session_estimate_pct,
+    get_safe_max_ram_pct,
     list_gui_sessions,
     get_ecs_task_id,
     get_container_total_memory,
@@ -30,12 +33,10 @@ from aind_ephys_portal.panel.logging import (
 )
 from aind_ephys_portal.panel.utils import PostMessageListener, FullscreenResizeHandler
 
-# Refuse to admit a new session if the task's RAM is already above this percent,
-# regardless of how many sessions are active. Protects "poisoned" tasks
-# (residue from prior sessions) from being pushed into OOM by the count-based
-# admission rule. Picked below the /health 503 recycle threshold so the ALB
-# pulls the task out of rotation before the GUI starts rejecting.
-MAX_RAM_PERCENT_FOR_NEW_SESSION = 55
+# Admission is now decided dynamically by can_admit_new_session() in logging.py,
+# which predicts post-admit RAM and rejects above SAFE_MAX_RAM_PCT or beyond
+# HARD_CAP_SESSIONS. The old fixed MAX_RAM_PERCENT_FOR_NEW_SESSION constant has
+# been removed — it is subsumed by SAFE_MAX_RAM_PCT - PER_SESSION_ESTIMATE_PCT.
 
 displayed_unit_properties = [
     "decoder_label",
@@ -182,22 +183,29 @@ class EphysGuiView(param.Parameterized):
         )
 
         num_gui_sessions = len(list_gui_sessions())
-        max_sessions = get_max_number_of_gui_sessions()
         ram_percent = get_container_used_memory() / get_container_total_memory() * 100
-        too_many_sessions = num_gui_sessions > max_sessions
-        too_much_ram = ram_percent > MAX_RAM_PERCENT_FOR_NEW_SESSION
-        if too_many_sessions or too_much_ram:
+        # NB: this is the entry point for THIS session, so it isn't counted in
+        # num_gui_sessions yet — can_admit_new_session predicts what RAM would
+        # look like AFTER this admit and rejects if it'd cross the safe ceiling
+        # or the hard cap.
+        if not can_admit_new_session(current_count=num_gui_sessions, used_pct=ram_percent):
             # Remove this session from the count — it is being rejected
             doc = pn.state.curdoc
             route = getattr(doc, "_log_route", None)
             session_id = getattr(doc, "_log_session_id", None)
             if route and session_id:
                 remove_session(route, session_id)
-            reason = (
-                f"too many sessions ({num_gui_sessions}/{max_sessions})"
-                if too_many_sessions
-                else f"task RAM already at {ram_percent:.1f}% (limit {MAX_RAM_PERCENT_FOR_NEW_SESSION}%)"
-            )
+            hard_cap = get_hard_cap_sessions()
+            est_pct = get_per_session_estimate_pct()
+            safe_max = get_safe_max_ram_pct()
+            if num_gui_sessions >= hard_cap:
+                reason = f"hard session cap reached ({num_gui_sessions}/{hard_cap})"
+            else:
+                reason = (
+                    f"insufficient RAM headroom: current {ram_percent:.1f}% + "
+                    f"~{est_pct:.0f}% (est. per session) would exceed safe ceiling "
+                    f"{safe_max:.0f}%"
+                )
             print(f"Rejecting new session: {reason}. Task ID: {task_id}")
             self.layout = pn.Column(
                 header,

--- a/src/aind_ephys_portal/panel/ephys_gui.py
+++ b/src/aind_ephys_portal/panel/ephys_gui.py
@@ -5,11 +5,27 @@ import psutil
 import param
 import time
 import gc
+import warnings
 from copy import deepcopy
 
 import panel as pn
 
 pn.extension("tabulator", "gridstack")
+
+# Silence sklearn's InconsistentVersionWarning during analyzer load. The
+# warning itself is informational, but some upstream code in the
+# spikeinterface / spikeinterface-gui stack constructs the warning class
+# with a positional arg, which crashes because its __init__ is kwarg-only
+# (`__init__() takes 1 positional argument but 2 were given`). Suppressing
+# the warning prevents any reactive code path that re-emits it from firing.
+# Belt-and-braces with the scikit-learn==1.8.0 pin in the Dockerfile, which
+# avoids the version mismatch in the common case but doesn't help when
+# loading older analyzers saved with sklearn < 1.8.0.
+try:
+    from sklearn.exceptions import InconsistentVersionWarning
+    warnings.filterwarnings("ignore", category=InconsistentVersionWarning)
+except ImportError:
+    pass
 
 
 from spikeinterface_gui import run_mainwindow
@@ -474,12 +490,63 @@ class EphysGuiView(param.Parameterized):
         if sigui_win is not None:
             controller = getattr(sigui_win, "controller", None)
             if controller is not None:
-                # Clear views list — each view has param watchers holding back-refs
+                # Break the SignalHandler ↔ Controller back-edge BEFORE we
+                # touch the views, so even partial failures still detach the
+                # graph from the controller.
+                signal_handler = getattr(controller, "signal_handler", None)
+                if signal_handler is not None:
+                    try:
+                        signal_handler.controller = None
+                    except Exception:
+                        pass
+
+                # Each view has TWO sets of param watchers, plus three back-refs
+                # to the controller graph that the gc cycle collector can't break
+                # because SignalHandler.controller is a strong external ref into
+                # the cycle. Break them all here:
+                #   - view.settings._parameterized watchers   (settings change → refresh)
+                #   - view.notifier watchers                  (signal handler → 8 bound methods)
+                #   - view.notifier.view = view               (direct cycle)
+                #   - view.controller = controller            (back-ref)
+                #   - view.tour_timer (ndscatterview only)    (pn.state.add_periodic_callback)
                 for view in list(getattr(controller, "views", [])):
                     try:
                         view.settings._parameterized.param.unwatch_all()
                     except Exception:
                         pass
+                    try:
+                        view.notifier.param.unwatch_all()
+                    except Exception:
+                        pass
+                    notifier = getattr(view, "notifier", None)
+                    if notifier is not None:
+                        try:
+                            notifier.view = None
+                        except Exception:
+                            pass
+                    try:
+                        view.notifier = None
+                    except Exception:
+                        pass
+                    try:
+                        view.controller = None
+                    except Exception:
+                        pass
+                    # Stop per-view periodic callbacks. Only ndscatterview's
+                    # "Random tour" registers one today, but list-driven so
+                    # adding new ones upstream doesn't silently leak.
+                    for cb_attr in ("tour_timer",):
+                        cb = getattr(view, cb_attr, None)
+                        if cb is not None:
+                            try:
+                                cb.stop()
+                            except Exception:
+                                pass
+                            try:
+                                setattr(view, cb_attr, None)
+                            except Exception:
+                                pass
+
                 controller.views = []
                 # Clear PanelMainWindow's view dicts too
                 sigui_win.views = {}

--- a/src/aind_ephys_portal/panel/logging.py
+++ b/src/aind_ephys_portal/panel/logging.py
@@ -144,17 +144,70 @@ def get_container_used_memory():
     return psutil.virtual_memory().used
 
 
-def get_max_number_of_gui_sessions():
-    # Estimate number of sessions per worker for health check.
-    if "MAX_GUI_SESSIONS_PER_TASK" in os.environ:
-        print(f"Using MAX_GUI_SESSIONS_PER_TASK from environment: {os.environ['MAX_GUI_SESSIONS_PER_TASK']}")
-        MAX_SESSIONS_PER_WORKER = int(os.environ["MAX_GUI_SESSIONS_PER_TASK"])
-    else:
-        SESSION_AVG_RAM_USAGE_GB = 6
-        TOTAL_RAM_GB = get_container_total_memory() / (1024**3)
-        MAX_SESSIONS_PER_WORKER = int(np.floor(TOTAL_RAM_GB / SESSION_AVG_RAM_USAGE_GB))
+# --- Dynamic session admission ---
+#
+# The old static cap (`floor(total_ram / 6 GB)`) was too coarse:
+#   - It admits a 2nd heavy session on a task already at 60% RAM (→ OOM)
+#   - It rejects a 3rd light session on a task at 30% RAM (→ wasted capacity)
+#
+# New model: admit iff (current_used + per_session_estimate) < safe_max,
+# capped by an absolute session-count ceiling as a safety net. Each knob is
+# env-tunable so we can adjust without redeploys.
 
-    return MAX_SESSIONS_PER_WORKER
+
+def get_safe_max_ram_pct():
+    """Never voluntarily push RAM above this percent of container memory."""
+    return float(os.environ.get("SAFE_MAX_RAM_PCT", "75"))
+
+
+def get_per_session_estimate_pct():
+    """Rough peak RAM cost of one session as a percent of container memory.
+
+    Used to predict post-admit RAM before deciding whether to admit. Should
+    be on the pessimistic side — better to under-admit than OOM.
+    """
+    return float(os.environ.get("PER_SESSION_ESTIMATE_PCT", "25"))
+
+
+def get_hard_cap_sessions():
+    """Absolute ceiling on concurrent sessions per task.
+
+    Independent of RAM headroom — protects against estimate errors and from
+    operational issues (many Bokeh documents + periodic callbacks on one
+    process). Also lets the legacy ``MAX_GUI_SESSIONS_PER_TASK`` env var
+    keep working as an override.
+    """
+    if "MAX_GUI_SESSIONS_PER_TASK" in os.environ:
+        return int(os.environ["MAX_GUI_SESSIONS_PER_TASK"])
+    return int(os.environ.get("HARD_CAP_SESSIONS", "4"))
+
+
+def can_admit_new_session(current_count=None, used_pct=None):
+    """Return True iff this task should accept one more session right now.
+
+    Predicts post-admit RAM as ``current_used + per_session_estimate`` and
+    rejects if it'd exceed ``SAFE_MAX_RAM_PCT`` or if the hard count cap is
+    already reached. Caller may pass ``current_count`` and ``used_pct`` to
+    avoid a second filesystem/cgroup read per request.
+    """
+    if current_count is None:
+        current_count = len(list_gui_sessions())
+    if current_count >= get_hard_cap_sessions():
+        return False
+    if used_pct is None:
+        used_pct = get_container_used_memory() / get_container_total_memory() * 100
+    projected = used_pct + get_per_session_estimate_pct()
+    return projected < get_safe_max_ram_pct()
+
+
+def get_max_number_of_gui_sessions():
+    """Backward-compatible alias for :func:`get_hard_cap_sessions`.
+
+    Kept so existing imports and the ``--max-sessions`` CLI flag continue
+    to work. New code should prefer :func:`can_admit_new_session`, which
+    accounts for actual RAM headroom rather than a static count.
+    """
+    return get_hard_cap_sessions()
 
 
 class MultiSessionTee(io.TextIOBase):


### PR DESCRIPTION
# Dynamic, RAM-aware session admission + fix leak from unbroken SI-GUI back-refs

## Why (memory leak fix)

Live `/debug/memory` measurement on a poisoned task showed ~1.9M Python objects retained after closing one heavy session — mostly `dict`/`list`/`OrderedDict` (Bokeh model bookkeeping). Notably, numpy buffer memory and fsspec caches were already clean. The leak was *not* in the heavy data; it was in the Bokeh/Panel object graph that owns each session's view models.

Tracing through `spikeinterface-gui`'s `backend_panel.py`, every view registers **8 watchers** on its `notifier` via `SignalHandler.connect_view()`. Each watcher holds a bound method on `SignalHandler`, and `SignalHandler.controller` is a strong external reference back into the controller graph. Our previous `cleanup()` unwatched `view.settings._parameterized` but not `view.notifier`, so the entire watcher chain stayed alive — keeping every view, the controller, and tens of thousands of Bokeh model bookkeeping dicts reachable.

Three additional back-refs we also weren't breaking:

| Back-ref | Where set (sigui) |
|----------|-------------------|
| `view.notifier.view = view` | `backend_panel.py:22` (direct cycle) |
| `view.controller = controller` | `view_base.py:18` |
| `signal_handler.controller = controller` | `backend_panel.py:57` |

Plus per-view periodic callbacks (only `ndscatterview.tour_timer` registers one via `pn.state.add_periodic_callback`, fired by the "Random tour" button) — not stopped at teardown.

### Fix

In `EphysGuiView.cleanup()`, augmented the views-iteration block to:
- `view.notifier.param.unwatch_all()` (the SI-GUI watcher chain we were missing)
- `view.notifier.view = None`, `view.notifier = None`, `view.controller = None`
- Stop and null `view.tour_timer` if set
- Null `signal_handler.controller` *before* nulling `controller.signal_handler`

These should make the Controller and all view objects gc-reachable as pure cycles, which `gc.collect()` can then collect. The intent is for `/debug/memory` post-cleanup to drop from ~1.9M objects back near the ~250k warm baseline.

If this validates, the same change should land upstream in `spikeinterface-gui` (the watcher chain is a generic issue with the panel backend, not specific to our portal).

## Why (dynamic session admission)

The previous static cap (`max_sessions = floor(total_ram / 6 GB)`, ~2 per task) had two opposite failure modes, both confirmed in production monitoring:

| Scenario | Static-cap behavior | Right behavior |
|----------|---------------------|----------------|
| 2 light sessions @ 30% total RAM | Reject 3rd (count cap) | Admit — plenty of headroom |
| 1 heavy session @ 60% RAM | Admit 2nd (count not hit) → OOM risk | Reject — 2nd would push to ~95% |

The prior PR's `MAX_RAM_PERCENT_FOR_NEW_SESSION` was a band-aid that only addressed the second case after the fact. This PR replaces the count-based cap with a *predicted-RAM* admission rule that handles both cases uniformly.

## Model

Admit a new session iff:

```
(current_used_ram_pct + per_session_estimate_pct) < safe_max_ram_pct
AND
current_session_count < hard_cap_sessions
```

The hard cap is a safety net independent of RAM — protects against estimate errors and the operational cost of many Bokeh documents on one process (periodic callbacks, watchers, etc.).

All four tunables are env-overridable so we can adjust without redeploys:

| Knob | Default | Env var | Purpose |
|------|---------|---------|---------|
| Safe max RAM | 75% | `SAFE_MAX_RAM_PCT` | Never voluntarily push past this |
| Per-session estimate | 25% | `PER_SESSION_ESTIMATE_PCT` | Conservative guess at one session's peak |
| Hard session cap | 4 | `HARD_CAP_SESSIONS` (or legacy `MAX_GUI_SESSIONS_PER_TASK`) | Absolute ceiling regardless of RAM |
| Recycle threshold | 50% | `RECYCLE_RAM_PERCENT_WHEN_IDLE` | Unchanged from prior PR |

## Changes

- **New helpers in `logging.py`:** `can_admit_new_session()`, `get_safe_max_ram_pct()`, `get_per_session_estimate_pct()`, `get_hard_cap_sessions()`.
- **`get_max_number_of_gui_sessions()`** kept as a backward-compat alias for the hard cap so the `--max-sessions` CLI flag and `MAX_GUI_SESSIONS_PER_TASK` env var still work.
- **`EphysGuiView.__init__`** admission check now calls `can_admit_new_session()`. The old `MAX_RAM_PERCENT_FOR_NEW_SESSION` constant is removed (subsumed). Rejection message shows the actual cause: hard cap hit, or insufficient RAM headroom with the math.
- **`/health`** now collapses the old "Busy (RAM Usage)" and "Busy (MAX SESSIONS REACHED)" branches into one `Busy (FULL)` path triggered by `num_sessions > 0 AND not can_admit_new_session()`. The inflate-on-full behavior is preserved with the same timing, but fires accurately for both light-many and heavy-few cases.

## Behaviour preserved

- Inflate-on-full still signals ECS to scale up.
- Idle-recycle 503 path (`sessions == 0 AND RAM > 50%`) unchanged.
- `MALLOC_ARENA_MAX=2`, per-session cleanup, deferred GC — unchanged.

## Caveat (deferred to a follow-up)

A session **just admitted** hasn't allocated its RAM yet, so within the first ~30s of loading, the next admission decision sees too-low `used_pct` and could admit again. Mitigation would be a "pending-allocation reservation" — count each recently-admitted session as already consuming its estimated RAM for ~60s. Not included in this PR to keep the change small. With the 25% per-session estimate (conservative) and a 75% safe ceiling, the immediate worst case is bounded.

## Risk

- The per-session estimate is still a guess; conservative 25% wastes some headroom on tasks doing only light work, but never OOMs. Tunable via env var.
- `/health` response format changed slightly: now says `(hard cap N)` instead of `(max N)`. Any external monitoring that parses this should be updated, but I don't expect any.
- Removed `MAX_RAM_PERCENT_FOR_NEW_SESSION` is internal — no API surface.
